### PR TITLE
Consider plugged in as charging

### DIFF
--- a/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
+++ b/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
@@ -263,6 +263,7 @@ class SyncthingService : Service(), SyncthingStatusReceiver,
             val status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1)
             val isCharging = status == BatteryManager.BATTERY_STATUS_CHARGING
                     || status == BatteryManager.BATTERY_STATUS_FULL
+                    || intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, 0) != 0
 
             val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
             val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)


### PR DESCRIPTION
There are scenarios when the device is neither charging nor fully charged but has a charger connected, for example battery preservation features that disable or delay charging under certain conditions.

This considers a plugged-in charger as "charging" as a charger typically provides enough power to at least maintain the battery level.