### PR TITLE
Disable badge for persistent notifications by default

### DIFF
--- a/app/src/main/java/com/chiller3/basicsync/Notifications.kt
+++ b/app/src/main/java/com/chiller3/basicsync/Notifications.kt
@@ -37,6 +37,7 @@ class Notifications(private val context: Context) {
         NotificationManager.IMPORTANCE_LOW,
     ).apply {
         description = context.getString(R.string.notification_channel_persistent_desc)
+        setShowBadge(false)
     }
 
     private fun createFailureAlertsChannel() = NotificationChannel(


### PR DESCRIPTION
This only changes the default for new installations. Existing users will have to manually change their settings if they don't like the dot.