### PR TITLE
webview_bridge: Explicitly send input event when updating fields

### DIFF
--- a/app/src/main/res/raw/webview_bridge.js
+++ b/app/src/main/res/raw/webview_bridge.js
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2025-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -166,10 +166,12 @@ function tryMutate() {
 
 function onFolderSelected(path) {
     elemFolderPath.value = path;
+    elemFolderPath.dispatchEvent(new InputEvent('input'));
 }
 
 function onDeviceIdScanned(deviceId) {
     elemDeviceId.value = deviceId;
+    elemDeviceId.dispatchEvent(new InputEvent('input'));
 }
 
 if (!tryMutate()) {


### PR DESCRIPTION
Angular does not automatically detect when the value of an `<input>` element is programatically changed. This caused the save button to not be enabled after selecting a folder path or scanning a device QR code.