### PR TITLE
Make minimum battery level customizable

### DIFF
--- a/app/src/main/java/com/chiller3/basicsync/MainApplication.kt
+++ b/app/src/main/java/com/chiller3/basicsync/MainApplication.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023-2025 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -34,7 +34,9 @@ class MainApplication : Application() {
 
         Notifications(this).updateChannels()
 
-        // Enable Material You colors
+        // Enable Material You colors.
         DynamicColors.applyToActivitiesIfAvailable(this)
+
+        Preferences(this).migrate()
     }
 }

--- a/app/src/main/java/com/chiller3/basicsync/Preferences.kt
+++ b/app/src/main/java/com/chiller3/basicsync/Preferences.kt
@@ -18,7 +18,8 @@ class Preferences(context: Context) {
 
         // Main preferences.
         const val PREF_REQUIRE_UNMETERED_NETWORK = "require_unmetered_network"
-        const val PREF_REQUIRE_SUFFICIENT_BATTERY = "require_sufficient_battery"
+        const val PREF_RUN_ON_BATTERY = "run_on_battery"
+        const val PREF_MIN_BATTERY_LEVEL = "min_battery_level"
         const val PREF_RESPECT_BATTERY_SAVER = "respect_battery_saver"
         const val PREF_KEEP_ALIVE = "keep_alive"
 
@@ -39,6 +40,9 @@ class Preferences(context: Context) {
         const val PREF_DEBUG_MODE = "debug_mode"
         const val PREF_MANUAL_MODE = "manual_mode"
         const val PREF_MANUAL_SHOULD_RUN = "manual_should_run"
+
+        // Legacy preferences.
+        private const val PREF_REQUIRE_SUFFICIENT_BATTERY = "require_sufficient_battery"
     }
 
     private val prefs = PreferenceManager.getDefaultSharedPreferences(context)
@@ -55,9 +59,13 @@ class Preferences(context: Context) {
         get() = prefs.getBoolean(PREF_REQUIRE_UNMETERED_NETWORK, true)
         set(enabled) = prefs.edit { putBoolean(PREF_REQUIRE_UNMETERED_NETWORK, enabled) }
 
-    var requireSufficientBattery: Boolean
-        get() = prefs.getBoolean(PREF_REQUIRE_SUFFICIENT_BATTERY, true)
-        set(enabled) = prefs.edit { putBoolean(PREF_REQUIRE_SUFFICIENT_BATTERY, enabled) }
+    var runOnBattery: Boolean
+        get() = prefs.getBoolean(PREF_RUN_ON_BATTERY, true)
+        set(enabled) = prefs.edit { putBoolean(PREF_RUN_ON_BATTERY, enabled) }
+
+    var minBatteryLevel: Int
+        get() = prefs.getInt(PREF_MIN_BATTERY_LEVEL, 20)
+        set(level) = prefs.edit { putInt(PREF_MIN_BATTERY_LEVEL, level) }
 
     var respectBatterySaver: Boolean
         get() = prefs.getBoolean(PREF_RESPECT_BATTERY_SAVER, true)
@@ -78,4 +86,14 @@ class Preferences(context: Context) {
     var manualShouldRun: Boolean
         get() = prefs.getBoolean(PREF_MANUAL_SHOULD_RUN, false)
         set(enabled) = prefs.edit { putBoolean(PREF_MANUAL_SHOULD_RUN, enabled) }
+
+    fun migrate() {
+        if (prefs.contains(PREF_REQUIRE_SUFFICIENT_BATTERY)) {
+            if (!prefs.getBoolean(PREF_REQUIRE_SUFFICIENT_BATTERY, true)) {
+                minBatteryLevel = 0
+            }
+
+            prefs.edit { remove(PREF_REQUIRE_SUFFICIENT_BATTERY) }
+        }
+    }
 }

--- a/app/src/main/java/com/chiller3/basicsync/dialog/MinBatteryLevelDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/basicsync/dialog/MinBatteryLevelDialogFragment.kt
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: 2024-2026 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.basicsync.dialog
+
+import android.annotation.SuppressLint
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import android.text.InputType
+import android.view.Gravity
+import androidx.appcompat.app.AlertDialog
+import androidx.core.os.bundleOf
+import androidx.core.widget.addTextChangedListener
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import com.chiller3.basicsync.Preferences
+import com.chiller3.basicsync.R
+import com.chiller3.basicsync.databinding.DialogTextInputBinding
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+
+class MinBatteryLevelDialogFragment : DialogFragment() {
+    companion object {
+        val TAG: String = MinBatteryLevelDialogFragment::class.java.simpleName
+
+        const val RESULT_SUCCESS = "success"
+    }
+
+    private lateinit var prefs: Preferences
+    private lateinit var binding: DialogTextInputBinding
+    private var minBatteryLevel: Int? = null
+    private var success: Boolean = false
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        prefs = Preferences(requireContext())
+
+        binding = DialogTextInputBinding.inflate(layoutInflater)
+        binding.message.text = getString(R.string.dialog_min_battery_level_message)
+        binding.textLayout.hint = getString(R.string.dialog_min_battery_level_hint)
+        binding.text.inputType = InputType.TYPE_CLASS_NUMBER
+        binding.text.addTextChangedListener {
+            minBatteryLevel = try {
+                val level = it.toString().toInt()
+                if (level in 0..100) {
+                    level
+                } else {
+                    null
+                }
+            } catch (_: Exception) {
+                null
+            }
+
+            refreshOkButtonEnabledState()
+        }
+        if (savedInstanceState == null) {
+            @SuppressLint("SetTextI18n")
+            binding.text.setText(prefs.minBatteryLevel.toString())
+        }
+
+        return MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.dialog_min_battery_level_title)
+            .setView(binding.root)
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                prefs.minBatteryLevel = minBatteryLevel!!
+                success = true
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .create()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        refreshOkButtonEnabledState()
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+
+        setFragmentResult(tag!!, bundleOf(RESULT_SUCCESS to success))
+    }
+
+    private fun refreshOkButtonEnabledState() {
+        (dialog as AlertDialog?)?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled =
+            minBatteryLevel != null
+    }
+}

--- a/app/src/main/java/com/chiller3/basicsync/view/SplitSwitchPreference.kt
+++ b/app/src/main/java/com/chiller3/basicsync/view/SplitSwitchPreference.kt
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.basicsync.view
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.preference.PreferenceViewHolder
+import androidx.preference.SwitchPreferenceCompat
+import com.chiller3.basicsync.R
+
+/**
+ * A switch preference with a divider between the main preference and the switch. It is both
+ * clickable and switchable.
+ */
+class SplitSwitchPreference : SwitchPreferenceCompat {
+    constructor(context: Context) : this(context, null)
+
+    constructor(context: Context, attrs: AttributeSet?) :
+            this(context, attrs, R.attr.splitSwitchPreferenceStyle)
+
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) :
+            this(context, attrs, defStyleAttr, 0)
+
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) :
+            super(context, attrs, defStyleAttr, defStyleRes)
+
+    override fun onBindViewHolder(holder: PreferenceViewHolder) {
+        super.onBindViewHolder(holder)
+
+        val switchView = holder.findViewById(androidx.preference.R.id.switchWidget)
+
+        // Perform the toggling only when clicking the switch itself.
+        switchView.isClickable = true
+    }
+
+    override fun onClick() {
+        // Don't toggle the switch when clicking the main preference area.
+    }
+}

--- a/app/src/main/res/layout/split_switch_preference.xml
+++ b/app/src/main/res/layout/split_switch_preference.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    SPDX-FileCopyrightText: 2024-2026 Andrew Gunnerson
+    SPDX-License-Identifier: GPL-3.0-only
+-->
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:gravity="end|center_vertical"
+    android:orientation="horizontal"
+    android:paddingTop="16dp"
+    android:paddingBottom="16dp">
+    <View
+        android:layout_width="1dp"
+        android:layout_height="40dp"
+        android:layout_marginStart="?android:attr/listPreferredItemPaddingStart"
+        android:layout_marginEnd="?android:attr/listPreferredItemPaddingEnd"
+        android:background="?attr/colorOutline" />
+
+    <include layout="@layout/material_switch_preference" />
+</LinearLayout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+    SPDX-License-Identifier: GPL-3.0-only
+-->
+<resources>
+    <declare-styleable name="SplitSwitchPreference">
+        <attr name="splitSwitchPreferenceStyle" format="reference" />
+    </declare-styleable>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,8 +31,8 @@
     <string name="pref_auto_mode_desc">Automatically start and stop based on the specified conditions.</string>
     <string name="pref_require_unmetered_network_name">Require unmetered network</string>
     <string name="pref_require_unmetered_network_desc">Only run if the device is connected to an unmetered network (eg. Wi-Fi).</string>
-    <string name="pref_require_sufficient_battery_name">Require sufficient battery level</string>
-    <string name="pref_require_sufficient_battery_desc">Only run if the battery level is not low or if the device is charging.</string>
+    <string name="pref_run_on_battery_name">Run on battery power</string>
+    <string name="pref_run_on_battery_desc">Run when the device is on battery power and the battery level is at least %1$d%%. Syncthing always runs when plugged in.</string>
     <string name="pref_respect_battery_saver_name">Respect battery saver mode</string>
     <string name="pref_respect_battery_saver_desc">Only run when Android\'s battery saver mode is disabled.</string>
     <string name="pref_keep_alive_name">Keep Syncthing alive</string>
@@ -57,6 +57,9 @@
     <string name="dialog_new_folder_title">New folder</string>
     <string name="dialog_new_folder_message">Enter the name of the new folder to create in %1$s.</string>
     <string name="dialog_new_folder_hint">Name</string>
+    <string name="dialog_min_battery_level_title">Minimum battery level</string>
+    <string name="dialog_min_battery_level_message">Enter the minimum battery level needed for Syncthing to run.</string>
+    <string name="dialog_min_battery_level_hint">Percentage</string>
 
     <!-- Web UI extra buttons -->
     <string name="web_ui_select_folder">Select folder</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -7,4 +7,8 @@
     <style name="SwitchPreferenceCompat.Material3" parent="Preference.SwitchPreferenceCompat.Material">
         <item name="android:widgetLayout">@layout/material_switch_preference</item>
     </style>
+
+    <style name="SplitSwitchPreference.Material3" parent="Preference.SwitchPreferenceCompat.Material">
+        <item name="android:widgetLayout">@layout/split_switch_preference</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -7,5 +7,6 @@
     <style name="Theme.BasicSync" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="switchPreferenceCompatStyle">@style/SwitchPreferenceCompat.Material3</item>
+        <item name="splitSwitchPreferenceStyle">@style/SplitSwitchPreference.Material3</item>
     </style>
 </resources>

--- a/app/src/main/res/xml/preferences_root.xml
+++ b/app/src/main/res/xml/preferences_root.xml
@@ -89,11 +89,10 @@
             app:summary="@string/pref_require_unmetered_network_desc"
             app:iconSpaceReserved="false" />
 
-        <SwitchPreferenceCompat
-            app:key="require_sufficient_battery"
+        <com.chiller3.basicsync.view.SplitSwitchPreference
+            app:key="run_on_battery"
             app:defaultValue="true"
-            app:title="@string/pref_require_sufficient_battery_name"
-            app:summary="@string/pref_require_sufficient_battery_desc"
+            app:title="@string/pref_run_on_battery_name"
             app:iconSpaceReserved="false" />
 
         <SwitchPreferenceCompat


### PR DESCRIPTION
This replaces the old "Require sufficient battery" setting with a more flexible "Run on battery" split switch setting.

The old setting was just a plain old toggle with two states:

* On: Allow running when on battery and the level is >= 20%
* Off: Allow running when on battery always

The new setting is a toggle with a customizable threshold, but with different semantics:

* On: Allow running when on battery and the level is >= the configured threshold (defaults to 20%)
* Off: Do not allow running when on battery

The equivalent to the old "off" setting is "on" + level = 0%. The old setting will automatically be migrated to the new setting.

Issue: #14