### PR TITLE
stbridge: Update quic-go to 0.59.0

### DIFF
--- a/stbridge/go.mod
+++ b/stbridge/go.mod
@@ -51,13 +51,13 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.65.0 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
-	github.com/quic-go/quic-go v0.56.0 // indirect
+	github.com/quic-go/quic-go v0.59.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.25.6 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/syncthing/notify v0.0.0-20250528144937-c7027d4f7465 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/thejerf/suture/v4 v4.0.6 // indirect

--- a/stbridge/go.sum
+++ b/stbridge/go.sum
@@ -166,8 +166,8 @@ github.com/prometheus/common v0.65.0 h1:QDwzd+G1twt//Kwj/Ww6E9FQq1iVMmODnILtW1t2
 github.com/prometheus/common v0.65.0/go.mod h1:0gZns+BLRQ3V6NdaerOhMbwwRbNh9hkGINtQAsP5GS8=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
-github.com/quic-go/quic-go v0.56.0 h1:q/TW+OLismmXAehgFLczhCDTYB3bFmua4D9lsNBWxvY=
-github.com/quic-go/quic-go v0.56.0/go.mod h1:9gx5KsFQtw2oZ6GZTyh+7YEvOxWCL9WZAepnHxgAo6c=
+github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
+github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 h1:bsUq1dX0N8AOIL7EB/X911+m4EHsnWEHeJ0c+3TTBrg=
 github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
@@ -188,8 +188,9 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/syncthing/notify v0.0.0-20250528144937-c7027d4f7465 h1:yhxdTGmFkAM2TFA65c3NgGwpnIkUM8oVqPX2e9S7IVg=
 github.com/syncthing/notify v0.0.0-20250528144937-c7027d4f7465/go.mod h1:J0q59IWjLtpRIJulohwqEZvjzwOfTEPp8SVhDJl+y0Y=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDdvS342BElfbETmL1Aiz3i2t0zfRj16Hs=


### PR DESCRIPTION
Fixes the following intermittent panic:
```
panic: crypto/tls bug: where's my session ticket?

goroutine 1367 [running]:
github.com/quic-go/quic-go/internal/handshake.(*cryptoSetup).GetSessionTicket(0x68ae15ac360)
    github.com/quic-go/quic-go@v0.56.0/internal/handshake/crypto_setup.go:398 +0x28c
github.com/quic-go/quic-go.(*Conn).handleHandshakeComplete(0x68ae1632808, 0x37166e5225e)
    github.com/quic-go/quic-go@v0.56.0/connection.go:950 +0x1f0
github.com/quic-go/quic-go.(*Conn).handleFrames(0x68ae1632808, {0x68ae187d9ca?, 0x68ae187d9b7?, 0x68ae15a0720?}, {{0x7d, 0xea, 0x0, 0x24, 0x0, 0x0, ...}, ...}, ...)
    github.com/quic-go/quic-go@v0.56.0/connection.go:1861 +0xa28
github.com/quic-go/quic-go.(*Conn).handleUnpackedLongHeaderPacket(0x68ae1632808, 0x68ae1aef170, 0x1, 0x37166e5225e, 0x2e8)
    github.com/quic-go/quic-go@v0.56.0/connection.go:1703 +0x508
github.com/quic-go/quic-go.(*Conn).handleLongHeaderPacket(0x68ae1632808, {0x68ae1d42c80, {0xc98da64464e0, 0x68ae1aef020}, 0x37166e5225e, {0x68ae187d9b7, 0x2e8, 0x3f5}, 0x1, {{{0x0, ...}, ...}, ...}}, ...)
    github.com/quic-go/quic-go@v0.56.0/connection.go:1355 +0x82c
github.com/quic-go/quic-go.(*Conn).handleOnePacket(0x68ae1632808, {0x68ae1d42c80, {0xc98da64464e0, 0x68ae1aef020}, 0x37166e5225e, {0x68ae187d800, 0x500, 0x5ac}, 0x1, {{{0x0, ...}, ...}, ...}})
    github.com/quic-go/quic-go@v0.56.0/connection.go:1122 +0x428
github.com/quic-go/quic-go.(*Conn).handlePackets(0x68ae1632808)
    github.com/quic-go/quic-go@v0.56.0/connection.go:1012 +0x388
github.com/quic-go/quic-go.(*Conn).run(0x68ae1632808)
    github.com/quic-go/quic-go@v0.56.0/connection.go:658 +0x334
created by github.com/quic-go/quic-go.(*baseServer).handleInitialImpl in goroutine 1309
    github.com/quic-go/quic-go@v0.56.0/server.go:862 +0xd08
```