### PR TITLE
stbridge: Make configuration import atomic

### DIFF
--- a/app/src/main/java/com/chiller3/basicsync/MainApplication.kt
+++ b/app/src/main/java/com/chiller3/basicsync/MainApplication.kt
@@ -7,6 +7,7 @@ package com.chiller3.basicsync
 
 import android.app.Application
 import android.util.Log
+import com.chiller3.basicsync.binding.stbridge.Stbridge
 import com.google.android.material.color.DynamicColors
 import java.io.File
 
@@ -38,5 +39,7 @@ class MainApplication : Application() {
         DynamicColors.applyToActivitiesIfAvailable(this)
 
         Preferences(this).migrate()
+
+        Stbridge.initDirs(filesDir.toString(), cacheDir.toString())
     }
 }

--- a/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
+++ b/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
@@ -446,7 +446,6 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
 
             try {
                 Stbridge.run(SyncthingStartupConfig().apply {
-                    filesDir = this@SyncthingService.filesDir.toString()
                     deviceModel = Build.MODEL
                     proxy = proxyInfo.proxy
                     noProxy = proxyInfo.noProxy


### PR DESCRIPTION
Previously, the existing config directory would always be wiped out prior to extracting any files from the backup.