### PR TITLE
Add support for interval-based time schedule

### DIFF
--- a/app/src/main/java/com/chiller3/basicsync/Preferences.kt
+++ b/app/src/main/java/com/chiller3/basicsync/Preferences.kt
@@ -17,9 +17,11 @@ class Preferences(context: Context) {
         const val CATEGORY_DEBUG = "debug"
 
         // Main preferences.
+        const val PREF_AUTO_MODE = "auto_mode"
         const val PREF_RUN_ON_BATTERY = "run_on_battery"
         const val PREF_MIN_BATTERY_LEVEL = "min_battery_level"
         const val PREF_RESPECT_BATTERY_SAVER = "respect_battery_saver"
+        const val PREF_SYNC_SCHEDULE = "sync_schedule"
         const val PREF_KEEP_ALIVE = "keep_alive"
 
         // Main UI actions only.
@@ -31,7 +33,6 @@ class Preferences(context: Context) {
         const val PREF_IMPORT_CONFIGURATION = "import_configuration"
         const val PREF_EXPORT_CONFIGURATION = "export_configuration"
         const val PREF_SERVICE_STATUS = "service_status"
-        const val PREF_AUTO_MODE = "auto_mode"
         const val PREF_NETWORK_CONDITIONS = "network_conditions"
         const val PREF_VERSION = "version"
         const val PREF_SAVE_LOGS = "save_logs"
@@ -40,6 +41,8 @@ class Preferences(context: Context) {
         const val PREF_DEBUG_MODE = "debug_mode"
         const val PREF_MANUAL_MODE = "manual_mode"
         const val PREF_MANUAL_SHOULD_RUN = "manual_should_run"
+        const val PREF_SCHEDULE_CYCLE_MS = "schedule_cycle_ms"
+        const val PREF_SCHEDULE_SYNC_MS = "schedule_sync_ms"
 
         // Network condition preferences.
         const val CATEGORY_ALLOWED_WIFI_NETWORKS = "allowed_wifi_networks"
@@ -107,6 +110,18 @@ class Preferences(context: Context) {
     var allowedWifiNetworks: Set<String>
         get() = prefs.getStringSet(PREF_ALLOWED_WIFI_NETWORKS, emptySet())!!
         set(networks) = prefs.edit { putStringSet(PREF_ALLOWED_WIFI_NETWORKS, networks) }
+
+    var syncSchedule: Boolean
+        get() = prefs.getBoolean(PREF_SYNC_SCHEDULE, false)
+        set(enabled) = prefs.edit { putBoolean(PREF_SYNC_SCHEDULE, enabled) }
+
+    var scheduleCycleMs: Int
+        get() = prefs.getInt(PREF_SCHEDULE_CYCLE_MS, 60 * 60 * 1000)
+        set(ms) = prefs.edit { putInt(PREF_SCHEDULE_CYCLE_MS, ms) }
+
+    var scheduleSyncMs: Int
+        get() = prefs.getInt(PREF_SCHEDULE_SYNC_MS, 5 * 60 * 1000)
+        set(ms) = prefs.edit { putInt(PREF_SCHEDULE_SYNC_MS, ms) }
 
     var isDebugMode: Boolean
         get() = prefs.getBoolean(PREF_DEBUG_MODE, false)

--- a/app/src/main/java/com/chiller3/basicsync/dialog/SyncScheduleDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/basicsync/dialog/SyncScheduleDialogFragment.kt
@@ -1,0 +1,139 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.basicsync.dialog
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import android.text.InputType
+import androidx.appcompat.app.AlertDialog
+import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
+import androidx.core.widget.addTextChangedListener
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import com.chiller3.basicsync.Preferences
+import com.chiller3.basicsync.R
+import com.chiller3.basicsync.databinding.DialogTextInputBinding
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+
+class SyncScheduleDialogFragment : DialogFragment() {
+    companion object {
+        val TAG: String = SyncScheduleDialogFragment::class.java.simpleName
+
+        const val RESULT_SUCCESS = "success"
+
+        private fun msToHuman(duration: Int): String =
+            if (duration % (60 * 60 * 1000) == 0) {
+                val hours = duration / 60 / 60 / 1000
+                "${hours}h"
+            } else if (duration % (60 * 1000) == 0) {
+                val minutes = duration / 60 / 1000
+                "${minutes}m"
+            } else {
+                val seconds = duration / 1000
+                "${seconds}s"
+            }
+
+        private fun humanToMs(input: String): Int {
+            val multiplier = when (input.last()) {
+                'h' -> 60 * 60 * 1000
+                'm' -> 60 * 1000
+                's' -> 1000
+                else -> throw IllegalArgumentException("Unrecognized suffix in: $input")
+            }
+
+            val base = input.substring(0, input.length - 1).toInt()
+            if (base <= 0) {
+                throw IllegalArgumentException("Base value must be positive: $base")
+            } else if (base > Int.MAX_VALUE / multiplier) {
+                throw IllegalArgumentException("Duration too large as ms: $base * $multiplier")
+            }
+
+            return base * multiplier
+        }
+    }
+
+    private lateinit var prefs: Preferences
+    private lateinit var binding: DialogTextInputBinding
+    private var success: Boolean = false
+    private var cycleMs: Int? = null
+    private var syncMs: Int? = null
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val context = requireContext()
+
+        prefs = Preferences(context)
+
+        binding = DialogTextInputBinding.inflate(layoutInflater)
+        binding.message.setText(R.string.dialog_sync_schedule_message)
+
+        binding.textLayout.setHint(R.string.dialog_sync_schedule_hint_cycle)
+        binding.confirmTextLayout.setHint(R.string.dialog_sync_schedule_hint_sync)
+        binding.confirmTextLayout.isVisible = true
+
+        val inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
+        binding.text.inputType = inputType
+        binding.confirmText.inputType = inputType
+
+        binding.text.addTextChangedListener {
+            cycleMs = try {
+                humanToMs(it.toString())
+            } catch (_: Exception) {
+                null
+            }
+
+            refreshOkButtonEnabledState()
+        }
+        binding.confirmText.addTextChangedListener {
+            syncMs = try {
+                humanToMs(it.toString())
+            } catch (_: Exception) {
+                null
+            }
+
+            refreshOkButtonEnabledState()
+        }
+
+        if (savedInstanceState == null) {
+            binding.text.setText(msToHuman(prefs.scheduleCycleMs))
+            binding.confirmText.setText(msToHuman(prefs.scheduleSyncMs))
+        }
+
+        return MaterialAlertDialogBuilder(context)
+            .setTitle(R.string.dialog_sync_schedule_title)
+            .setView(binding.root)
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                success = true
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .create()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        refreshOkButtonEnabledState()
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+
+        if (success) {
+            prefs.scheduleCycleMs = cycleMs!!
+            prefs.scheduleSyncMs = syncMs!!
+        }
+
+        setFragmentResult(tag!!, bundleOf(RESULT_SUCCESS to success))
+    }
+
+    private fun refreshOkButtonEnabledState() {
+        val cycleMs = cycleMs
+        val syncMs = syncMs
+
+        (dialog as AlertDialog?)?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled =
+            cycleMs != null && syncMs != null && syncMs < cycleMs
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,8 @@
     <string name="pref_run_on_battery_desc">Run when the device is on battery power and the battery level is at least %1$d%%. Syncthing always runs when plugged in.</string>
     <string name="pref_respect_battery_saver_name">Respect battery saver mode</string>
     <string name="pref_respect_battery_saver_desc">Only run when Android\'s battery saver mode is disabled.</string>
+    <string name="pref_sync_schedule_name">Sync on time schedule</string>
+    <string name="pref_sync_schedule_desc">Sync for %2$s during every window of %1$s.</string>
     <string name="pref_keep_alive_name">Keep Syncthing alive</string>
     <string name="pref_keep_alive_desc">When Syncthing should not run, pause it instead of shutting it down. The avoids a potential performance hit when scanning large folders on startup.</string>
     <string name="pref_version_name">Version</string>
@@ -86,6 +88,10 @@
     <string name="dialog_min_battery_level_title">Minimum battery level</string>
     <string name="dialog_min_battery_level_message">Enter the minimum battery level needed for Syncthing to run.</string>
     <string name="dialog_min_battery_level_hint">Percentage</string>
+    <string name="dialog_sync_schedule_title">Sync schedule</string>
+    <string name="dialog_sync_schedule_message">Enter the cycle and sync duration. The <tt>h</tt> (hours), <tt>m</tt> (minutes), and <tt>s</tt> (seconds) suffixes are accepted.</string>
+    <string name="dialog_sync_schedule_hint_cycle">Cycle duration</string>
+    <string name="dialog_sync_schedule_hint_sync">Sync duration</string>
     <string name="dialog_wifi_network_title">Wi-Fi network</string>
     <string name="dialog_wifi_network_message">Enter the name (SSID) of the Wi-Fi network. This also works for hidden Wi-Fi networks.</string>
     <string name="dialog_wifi_network_hint">SSID</string>
@@ -113,4 +119,18 @@
     <string name="notification_action_manual_mode">Manual mode</string>
     <string name="notification_action_start">Start</string>
     <string name="notification_action_stop">Stop</string>
+
+    <!-- Durations -->
+    <plurals name="duration_seconds">
+        <item quantity="one">%d second</item>
+        <item quantity="other">%d seconds</item>
+    </plurals>
+    <plurals name="duration_minutes">
+        <item quantity="one">%d minute</item>
+        <item quantity="other">%d minutes</item>
+    </plurals>
+    <plurals name="duration_hours">
+        <item quantity="one">%d hour</item>
+        <item quantity="other">%d hours</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/xml/preferences_root.xml
+++ b/app/src/main/res/xml/preferences_root.xml
@@ -102,6 +102,11 @@
             app:summary="@string/pref_respect_battery_saver_desc"
             app:iconSpaceReserved="false" />
 
+        <com.chiller3.basicsync.view.SplitSwitchPreference
+            app:key="sync_schedule"
+            app:title="@string/pref_sync_schedule_name"
+            app:iconSpaceReserved="false" />
+
         <SwitchPreferenceCompat
             app:key="keep_alive"
             app:defaultValue="true"


### PR DESCRIPTION
The user can configure two durations:

* the length of the cycle interval (defaults to 1 hour)
* the length of time to sync at the beginning of each cycle (defaults to 5 minutes)

The reference point is the timestamp at which SyncthingService created DeviceStateTracker. All intervals are aligned to a "grid" rooted at the reference point. When the user changes the settings, the reference point does not get reset, so syncing might not start immediately.

Also, the schedule is based on the system uptime clock, which is monotonic, but may stop counting during certain deep sleep scenarios.

Issue: #14
Issue: #36