### PR TITLE
SyncthingService: Make service sticky

### DIFF
--- a/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
+++ b/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
@@ -300,7 +300,7 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
 
         stateChanged()
 
-        return START_NOT_STICKY
+        return START_STICKY
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {


### PR DESCRIPTION
Otherwise, Android won't restart it if the process is killed. This also fixes the service not relaunching after the user taps the restart apps notification for post-OTA dexopt.