### PR TITLE
Add support for remote control via broadcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,31 @@ The app is intentionally kept very basic so that the project is easy to maintain
 * `ACCESS_WIFI_STATE`, `ACCESS_COARSE_LOCATION`, `ACCESS_FINE_LOCATION`, `ACCESS_BACKGROUND_LOCATION`, `FOREGROUND_SERVICE_LOCATION`
     * Optionally used for stopping Syncthing unless connected to specific Wi-Fi networks.
 
-## Remote access
+## Remote web UI access
 
 Syncthing listens on the loopback interface and is available via `localhost` (both IPv4 `127.0.0.1` and IPv6 `::1`). BasicSync will try to use the same port on every start (with a default of 8384), but will automatically pick a new random port if there is a conflict. The current port number can be found in Web UI -> Actions -> Settings -> GUI. HTTPS and basic authentication are both forcibly enabled every time Syncthing starts.
 
 For basic authentication, the password is the API token. Generating new API tokens is supported, but setting an arbitrary password is not. BasicSync will internally set the password to the API token on every start.
+
+## Remote control
+
+When the "Allow remote control" setting is enabled, BasicSync allows other apps to control when Syncthing runs via Android's broadcast mechanism. The following broadcast actions are supported, which behave exactly the same as the corresponding buttons in BasicSync's notification:
+
+* `com.chiller3.basicsync.AUTO_MODE`
+    * Switch to auto mode where Syncthing runs based on the configured run conditions.
+* `com.chiller3.basicsync.MANUAL_MODE`
+    * Switch to manual mode where Syncthing is manually started and stopped, but maintain the existing state.
+    * If it was previously running, it will still be running. If it was previously stopped, it will still be stopped.
+* `com.chiller3.basicsync.START`
+    * Switch to manual mode and start Syncthing.
+* `com.chiller3.basicsync.STOP`
+    * Switch to manual mode and stop Syncthing.
+
+These broadcasts can also be sent via `adb`. For example:
+
+```bash
+adb shell am broadcast -a com.chiller3.basicsync.AUTO_MODE com.chiller3.basicsync
+```
 
 ## Verifying digital signatures
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -105,8 +105,19 @@
             android:exported="false" />
 
         <receiver
+            android:name=".syncthing.RemoteControlReceiver"
+            android:exported="true"
+            tools:ignore="ExportedReceiver">
+            <intent-filter>
+                <action android:name="${applicationId}.AUTO_MODE" />
+                <action android:name="${applicationId}.MANUAL_MODE" />
+                <action android:name="${applicationId}.START" />
+                <action android:name="${applicationId}.STOP" />
+            </intent-filter>
+        </receiver>
+
+        <receiver
             android:name=".syncthing.SyncthingBootReceiver"
-            android:enabled="true"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />

--- a/app/src/main/java/com/chiller3/basicsync/Preferences.kt
+++ b/app/src/main/java/com/chiller3/basicsync/Preferences.kt
@@ -24,6 +24,7 @@ class Preferences(context: Context) {
         const val PREF_RESPECT_AUTO_SYNC_DATA = "respect_auto_sync_data"
         const val PREF_SYNC_SCHEDULE = "sync_schedule"
         const val PREF_KEEP_ALIVE = "keep_alive"
+        const val PREF_REMOTE_CONTROL = "remote_control"
 
         // Main UI actions only.
         const val PREF_INHIBIT_BATTERY_OPT = "inhibit_battery_opt"
@@ -91,6 +92,10 @@ class Preferences(context: Context) {
     var keepAlive: Boolean
         get() = prefs.getBoolean(PREF_KEEP_ALIVE, true)
         set(enabled) = prefs.edit { putBoolean(PREF_KEEP_ALIVE, enabled) }
+
+    var remoteControl: Boolean
+        get() = prefs.getBoolean(PREF_REMOTE_CONTROL, false)
+        set(enabled) = prefs.edit { putBoolean(PREF_REMOTE_CONTROL, enabled) }
 
     var requireUnmeteredNetwork: Boolean
         get() = prefs.getBoolean(PREF_REQUIRE_UNMETERED_NETWORK, true)

--- a/app/src/main/java/com/chiller3/basicsync/syncthing/RemoteControlReceiver.kt
+++ b/app/src/main/java/com/chiller3/basicsync/syncthing/RemoteControlReceiver.kt
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.basicsync.syncthing
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.chiller3.basicsync.BuildConfig
+import com.chiller3.basicsync.Preferences
+
+class RemoteControlReceiver : BroadcastReceiver() {
+    companion object {
+        private val TAG = RemoteControlReceiver::class.java.simpleName
+
+        private const val ACTION_AUTO_MODE = "${BuildConfig.APPLICATION_ID}.AUTO_MODE"
+        private const val ACTION_MANUAL_MODE = "${BuildConfig.APPLICATION_ID}.MANUAL_MODE"
+        private const val ACTION_START = "${BuildConfig.APPLICATION_ID}.START"
+        private const val ACTION_STOP = "${BuildConfig.APPLICATION_ID}.STOP"
+    }
+
+    override fun onReceive(context: Context, intent: Intent?) {
+        if (!Preferences(context).remoteControl) {
+            Log.w(TAG, "Remote control is not allowed")
+            return
+        }
+
+        val serviceAction = when (intent?.action) {
+            ACTION_AUTO_MODE -> SyncthingService.ACTION_AUTO_MODE
+            ACTION_MANUAL_MODE -> SyncthingService.ACTION_MANUAL_MODE
+            ACTION_START -> SyncthingService.ACTION_START
+            ACTION_STOP -> SyncthingService.ACTION_STOP
+            else -> {
+                Log.w(TAG, "Ignoring unrecognized intent: $intent")
+                return
+            }
+        }
+
+        context.startForegroundService(SyncthingService.createIntent(context, serviceAction))
+    }
+}

--- a/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
+++ b/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
@@ -289,8 +289,16 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
                 prefs.manualShouldRun = shouldResume
                 prefs.isManualMode = true
             }
-            ACTION_START -> prefs.manualShouldRun = true
-            ACTION_STOP -> prefs.manualShouldRun = false
+            ACTION_START -> {
+                // This is reachable in auto mode via remote control.
+                prefs.manualShouldRun = true
+                prefs.isManualMode = true
+            }
+            ACTION_STOP -> {
+                // This is reachable in auto mode via remote control.
+                prefs.manualShouldRun = false
+                prefs.isManualMode = true
+            }
             ACTION_RENOTIFY -> synchronized(stateLock) {
                 forceShowNotification = true
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,8 @@
     <string name="pref_header_configuration">Configuration</string>
     <!-- Section header for preferences to configure when Syncthing is allowed to run. -->
     <string name="pref_header_run_conditions">Run conditions</string>
+    <!-- Section header for preferences related to advanced power-user functionality. -->
+    <string name="pref_header_advanced">Advanced</string>
     <!-- Section header for the preference showing information about the app, like version numbers. -->
     <string name="pref_header_about">About</string>
     <!-- Section header for hidden debug preferences. -->
@@ -73,6 +75,10 @@
     <string name="pref_keep_alive_name">Keep Syncthing alive</string>
     <!-- Description for the preference that keeps Syncthing always running. -->
     <string name="pref_keep_alive_desc">When Syncthing should not run, pause it instead of shutting it down. The avoids a potential performance hit when scanning large folders on startup.</string>
+    <!-- Title for the preference that allows external apps to control when Syncthing runs. -->
+    <string name="pref_remote_control_name">Allow remote control</string>
+    <!-- Description for the preference that allows external apps to control when Syncthing runs. -->
+    <string name="pref_remote_control_desc">Allow external apps to switch to auto mode or manually start and stop Syncthing.</string>
     <!-- Title for the preference that shows the version number. The description is two lines: the first line is BasicSync's version and the second line in Syncthing's version. -->
     <string name="pref_version_name">Version</string>
     <!-- Title for the debug preference that saves logs to a file. -->

--- a/app/src/main/res/xml/preferences_root.xml
+++ b/app/src/main/res/xml/preferences_root.xml
@@ -123,6 +123,17 @@
     </PreferenceCategory>
 
     <PreferenceCategory
+        app:title="@string/pref_header_advanced"
+        app:iconSpaceReserved="false">
+
+        <SwitchPreferenceCompat
+            app:key="remote_control"
+            app:title="@string/pref_remote_control_name"
+            app:summary="@string/pref_remote_control_desc"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
         app:title="@string/pref_header_about"
         app:iconSpaceReserved="false">
 


### PR DESCRIPTION
Remote control is disabled by default and only supports 4 actions:

* Switch to auto mode
* Switch to manual mode and maintain state
* Switch to manual mode and start service
* Switch to manual mode and stop service

It is intentionally not possible to change any actual settings via this mechanism.