### PR TITLE
stbridge: Set SOURCE_DATE_EPOCH when generating Syncthing assets

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -496,7 +496,10 @@ val stbridge = tasks.register("stbridge") {
                 "github.com/syncthing/syncthing/lib/api/auto",
                 "github.com/syncthing/syncthing/cmd/infra/strelaypoolsrv/auto",
             )
-            environment("PATH", "$binDir${File.pathSeparator}${environment["PATH"]}")
+            environment(
+                "PATH" to "$binDir${File.pathSeparator}${environment["PATH"]}",
+                "SOURCE_DATE_EPOCH" to stGitTimestamp,
+            )
             addGoEnvironment(this)
 
             workingDir(syncthingDir)


### PR DESCRIPTION
Fixes: https://gitlab.com/fdroid/fdroiddata/-/merge_requests/35348