### PR TITLE
stbridge: Don't replace 127.0.0.1 with ::1

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The app is intentionally kept very basic so that the project is easy to maintain
 
 ## Remote web UI access
 
-Syncthing listens on the loopback interface and is available via `localhost` (both IPv4 `127.0.0.1` and IPv6 `::1`). BasicSync will try to use the same port on every start (with a default of 8384), but will automatically pick a new random port if there is a conflict. The current port number can be found in Web UI -> Actions -> Settings -> GUI. HTTPS and basic authentication are both forcibly enabled every time Syncthing starts.
+Syncthing listens on the loopback interface and is available via `127.0.0.1:8384` by default. BasicSync will try to use the same port on every start, but will automatically pick a new random port if there is a conflict. The current port number can be found in Web UI -> Actions -> Settings -> GUI. HTTPS and basic authentication are both forcibly enabled every time Syncthing starts.
 
 For basic authentication, the password is the API token. Generating new API tokens is supported, but setting an arbitrary password is not. BasicSync will internally set the password to the API token on every start.
 

--- a/stbridge/stbridge.go
+++ b/stbridge/stbridge.go
@@ -17,7 +17,6 @@ import (
 	"io"
 	"log"
 	"log/slog"
-	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -280,15 +279,6 @@ func Run(startup *SyncthingStartupConfig) error {
 	go cfg.Serve(ctx)
 
 	waiter, err := cfg.Modify(func(c *config.Configuration) {
-		// Allow connecting over both IPv4 and IPv6 loopback.
-		if c.GUI.Network() == "tcp" {
-			guiHost, guiPort, err := net.SplitHostPort(c.GUI.Address())
-			if err == nil && guiHost == "127.0.0.1" {
-				log.Printf("Replacing 127.0.0.1 with ::1 for dual-stack")
-				c.GUI.RawAddress = net.JoinHostPort("::1", guiPort)
-			}
-		}
-
 		// Try to stick with existing ports, but always allow picking new ones
 		// so that running multiple instances of the app (eg. for debugging) is
 		// possible.


### PR DESCRIPTION
This was originally intended to make the GUI available via both IPv4 and IPv6 localhost, but the network stack doesn't actually work that way. Only listening on `::` has this behavior. Listening on specific addresses requires two sockets for dual stack and Syncthing only supports one socket.