### PR TITLE
Resend persistent notification when dismissed

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,16 +96,16 @@ adb shell am broadcast -a com.chiller3.basicsync.AUTO_MODE com.chiller3.basicsyn
 
 ## Persistent notification
 
-Android 14 and newer [no longer allow](https://developer.android.com/about/versions/14/behavior-changes-all#non-dismissable-notifications) regular apps to prevent notifications from being dismissed. If the persistent notification gets inadvertently dismissed, just open the app again and the notification will reappear.
+Android 14 and newer [no longer allow](https://developer.android.com/about/versions/14/behavior-changes-all#non-dismissable-notifications) regular apps to prevent persistent notifications from being dismissed. To work around this, BasicSync will automatically show the persistent notification again whenever it is dismissed.
 
-Alternatively, to prevent the notification from being dismissed, use adb to grant the `SYSTEM_EXEMPT_FROM_DISMISSIBLE_NOTIFICATIONS` appops permission:
+To prevent the notification from being dismissible in the first place (eliminating the UI jank from reshowing the notification), use adb to grant the `SYSTEM_EXEMPT_FROM_DISMISSIBLE_NOTIFICATIONS` appops permission:
 
 ```bash
 adb shell appops set com.chiller3.basicsync SYSTEM_EXEMPT_FROM_DISMISSIBLE_NOTIFICATIONS allow
-# To unfo the change, change "allow" to "default".
+# To undo the change, change "allow" to "default".
 ```
 
-Note that Syncthing will continue to run as normal even if the notification is not visible.
+Also, if the persistent notification is not desired, it can be disabled from Android's settings by turning off the "Background services" notification category for BasicSync. Syncthing will continue to run as normal even if the notification is not visible.
 
 ## Verifying digital signatures
 

--- a/app/src/main/java/com/chiller3/basicsync/Notifications.kt
+++ b/app/src/main/java/com/chiller3/basicsync/Notifications.kt
@@ -132,6 +132,18 @@ class Notifications(private val context: Context) {
             )
             setContentIntent(primaryPendingIntent)
 
+            val onDismissIntent = SyncthingService.createIntent(
+                context,
+                SyncthingService.ACTION_RENOTIFY,
+            )
+            val onDismissPendingIntent = PendingIntent.getService(
+                context,
+                0,
+                onDismissIntent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+            setDeleteIntent(onDismissPendingIntent)
+
             // Inhibit 10-second delay when showing persistent notification
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 setForegroundServiceBehavior(Notification.FOREGROUND_SERVICE_IMMEDIATE)


### PR DESCRIPTION
Android 14+ no longer allows the persistent notification to be dismissed, but that is the primary way for users to interact with the app. If the notification was dismissed, it was likely accidental, so let's resend the notification whenever it is dismissed.

Closes: #98