### PR TITLE
Add support for reporting sync conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The app is intentionally kept very basic so that the project is easy to maintain
 * Runs Syncthing as a library in the main process
     * This makes BasicSync immune to Android >=12's child process restrictions
 * Small additions to Syncthing's web UI to add a folder picker and QR code scanner
+* Detects and reports sync conflicts
 
 ## Limitations
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -88,6 +88,10 @@
         </activity>
 
         <activity
+            android:name=".settings.ConflictsActivity"
+            android:exported="false" />
+
+        <activity
             android:name=".settings.NetworkConditionsActivity"
             android:exported="false" />
 
@@ -96,7 +100,7 @@
             android:exported="false" />
 
         <!--
-            These config changes are ignored because WebView has no way of persisting the Javascript
+            These config changes are ignored because WebView has no way of persisting the JavaScript
             and DOM states. Only the history is preserved.
         -->
         <activity

--- a/app/src/main/java/com/chiller3/basicsync/Notifications.kt
+++ b/app/src/main/java/com/chiller3/basicsync/Notifications.kt
@@ -12,20 +12,26 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import com.chiller3.basicsync.extension.expandTilde
+import com.chiller3.basicsync.extension.shortenTilde
 import com.chiller3.basicsync.extension.toSingleLineString
+import com.chiller3.basicsync.settings.ConflictsActivity
 import com.chiller3.basicsync.settings.SettingsActivity
 import com.chiller3.basicsync.settings.WebUiActivity
 import com.chiller3.basicsync.syncthing.SyncthingService
+import java.io.File
 
 class Notifications(private val context: Context) {
     companion object {
         private const val CHANNEL_ID_PERSISTENT = "persistent"
         private const val CHANNEL_ID_FAILURE = "failure"
+        private const val CHANNEL_ID_CONFLICTS = "conflicts"
 
         private val LEGACY_CHANNEL_IDS = arrayOf<String>()
 
         const val ID_PERSISTENT = -1
         private const val ID_FAILURE = -2
+        private const val ID_CONFLICTS = -3
     }
 
     private val notificationManager = context.getSystemService(NotificationManager::class.java)
@@ -48,6 +54,14 @@ class Notifications(private val context: Context) {
         description = context.getString(R.string.notification_channel_failure_desc)
     }
 
+    private fun createConflictsAlertsChannel() = NotificationChannel(
+        CHANNEL_ID_CONFLICTS,
+        context.getString(R.string.notification_channel_conflicts_name),
+        NotificationManager.IMPORTANCE_HIGH,
+    ).apply {
+        description = context.getString(R.string.notification_channel_conflicts_desc)
+    }
+
     /**
      * Ensure notification channels are up-to-date.
      *
@@ -57,6 +71,7 @@ class Notifications(private val context: Context) {
         notificationManager.createNotificationChannels(listOf(
             createPersistentChannel(),
             createFailureAlertsChannel(),
+            createConflictsAlertsChannel(),
         ))
         LEGACY_CHANNEL_IDS.forEach { notificationManager.deleteNotificationChannel(it) }
     }
@@ -176,5 +191,52 @@ class Notifications(private val context: Context) {
         }
 
         notificationManager.notify(ID_FAILURE, notification)
+    }
+
+    fun sendOrClearConflictsNotification(conflicts: List<String>) {
+        if (conflicts.isEmpty()) {
+            notificationManager.cancel(ID_CONFLICTS)
+            return
+        }
+
+        val notification = Notification.Builder(context, CHANNEL_ID_CONFLICTS).run {
+            val text = buildString {
+                for ((i, conflict) in conflicts.withIndex()) {
+                    if (i > 0) {
+                        append("\n")
+                    }
+                    if (i == 3) {
+                        append('…')
+                        break
+                    } else {
+                        append(File(conflict).expandTilde().shortenTilde())
+                    }
+                }
+            }
+
+            setContentTitle(context.resources.getQuantityString(
+                R.plurals.notification_conflicts_title,
+                conflicts.size,
+                conflicts.size,
+            ))
+            setContentText(text)
+            style = Notification.BigTextStyle()
+            setSmallIcon(R.drawable.ic_notifications)
+
+            val intent = Intent(context, ConflictsActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            }
+            val pendingIntent = PendingIntent.getActivity(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+            setContentIntent(pendingIntent)
+
+            build()
+        }
+
+        notificationManager.notify(ID_CONFLICTS, notification)
     }
 }

--- a/app/src/main/java/com/chiller3/basicsync/Preferences.kt
+++ b/app/src/main/java/com/chiller3/basicsync/Preferences.kt
@@ -31,6 +31,7 @@ class Preferences(context: Context) {
         const val PREF_ALLOW_NOTIFICATIONS = "allow_notifications"
         const val PREF_LOCAL_STORAGE_ACCESS = "local_storage_access"
         const val PREF_DISABLE_APP_HIBERNATION = "disable_app_hibernation"
+        const val PREF_CONFLICTS = "conflicts"
         const val PREF_OPEN_WEB_UI = "open_web_ui"
         const val PREF_IMPORT_CONFIGURATION = "import_configuration"
         const val PREF_EXPORT_CONFIGURATION = "export_configuration"

--- a/app/src/main/java/com/chiller3/basicsync/dialog/FolderPickerDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/basicsync/dialog/FolderPickerDialogFragment.kt
@@ -20,6 +20,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.chiller3.basicsync.R
 import com.chiller3.basicsync.databinding.DialogFolderPickerBinding
+import com.chiller3.basicsync.extension.EXTERNAL_DIR
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.coroutines.launch
 import java.io.File
@@ -47,7 +48,7 @@ class FolderPickerDialogFragment : DialogFragment(), FolderPickerAdapter.Listene
 
         if (savedInstanceState == null) {
             val initialPath = arguments.getString(ARG_PATH)?.let { File(it) }
-            viewModel.navigate(initialPath ?: FolderPickerViewModel.EXTERNAL_DIR)
+            viewModel.navigate(initialPath ?: EXTERNAL_DIR)
         }
 
         val binding = DialogFolderPickerBinding.inflate(layoutInflater)

--- a/app/src/main/java/com/chiller3/basicsync/dialog/FolderPickerViewModel.kt
+++ b/app/src/main/java/com/chiller3/basicsync/dialog/FolderPickerViewModel.kt
@@ -1,14 +1,15 @@
 /*
- * SPDX-FileCopyrightText: 2025 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2025-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
 package com.chiller3.basicsync.dialog
 
-import android.annotation.SuppressLint
-import android.os.Environment
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.chiller3.basicsync.extension.EXTERNAL_DIR
+import com.chiller3.basicsync.extension.expandTilde
+import com.chiller3.basicsync.extension.shortenTilde
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -20,36 +21,9 @@ import java.text.Collator
 
 class FolderPickerViewModel : ViewModel() {
     companion object {
-        private val HOME = File("~")
-        @SuppressLint("SdCardPath")
-        private val SDCARD = File("/sdcard")
-        val EXTERNAL_DIR: File = Environment.getExternalStorageDirectory()
-
         // Same sorting method as AOSP's DocumentsUI.
         private val COLLATOR = Collator.getInstance().apply {
             strength = Collator.SECONDARY
-        }
-
-        private fun expandPath(path: File): File =
-            if (path.startsWith(HOME)) {
-                File(EXTERNAL_DIR, path.toRelativeString(HOME))
-            } else if (path.startsWith(SDCARD)) {
-                File(EXTERNAL_DIR, path.toRelativeString(SDCARD))
-            } else {
-                path
-            }
-
-        private fun shortenPath(path: File): File {
-            val relPath = path.relativeToOrSelf(EXTERNAL_DIR)
-            val relPathString = relPath.toString()
-
-            return if (relPathString.isEmpty()) {
-                HOME
-            } else if (!relPath.isAbsolute) {
-                File(HOME, relPathString)
-            } else {
-                relPath
-            }
         }
     }
 
@@ -59,7 +33,7 @@ class FolderPickerViewModel : ViewModel() {
         val childDirs: List<String>,
     ) {
         val shortCwd: File
-            get() = shortenPath(cwd)
+            get() = cwd.shortenTilde()
     }
 
     private val _state = MutableStateFlow(State(cwd = EXTERNAL_DIR, childDirs = emptyList()))
@@ -68,7 +42,7 @@ class FolderPickerViewModel : ViewModel() {
     fun navigate(path: File) {
         viewModelScope.launch {
             withContext(Dispatchers.IO) {
-                var newCwd = _state.value.cwd.resolve(expandPath(path)).normalize()
+                var newCwd = _state.value.cwd.resolve(path.expandTilde()).normalize()
 
                 // Don't allow paths outside of the internal storage. They aren't readable anyway.
                 var relPath = newCwd.toRelativeString(EXTERNAL_DIR)

--- a/app/src/main/java/com/chiller3/basicsync/extension/FileExtensions.kt
+++ b/app/src/main/java/com/chiller3/basicsync/extension/FileExtensions.kt
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.basicsync.extension
+
+import android.annotation.SuppressLint
+import android.os.Environment
+import java.io.File
+
+private val HOME = File("~")
+@SuppressLint("SdCardPath")
+private val SDCARD = File("/sdcard")
+val EXTERNAL_DIR: File = Environment.getExternalStorageDirectory()
+
+fun File.expandTilde(): File =
+    if (startsWith(HOME)) {
+        File(EXTERNAL_DIR, toRelativeString(HOME))
+    } else if (startsWith(SDCARD)) {
+        File(EXTERNAL_DIR, toRelativeString(SDCARD))
+    } else {
+        this
+    }
+
+fun File.shortenTilde(): File {
+    val relPath = relativeToOrSelf(EXTERNAL_DIR)
+    val relPathString = relPath.toString()
+
+    return if (relPathString.isEmpty()) {
+        HOME
+    } else if (!relPath.isAbsolute) {
+        File(HOME, relPathString)
+    } else {
+        relPath
+    }
+}

--- a/app/src/main/java/com/chiller3/basicsync/extension/UriExtensions.kt
+++ b/app/src/main/java/com/chiller3/basicsync/extension/UriExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2023-2026 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -8,12 +8,14 @@ package com.chiller3.basicsync.extension
 import android.content.ContentResolver
 import android.net.Uri
 
+const val DOCUMENTSUI_AUTHORITY = "com.android.externalstorage.documents"
+
 val Uri.formattedString: String
     get() = when (scheme) {
         ContentResolver.SCHEME_FILE -> path!!
         ContentResolver.SCHEME_CONTENT -> {
             val prefix = when (authority) {
-                "com.android.externalstorage.documents" -> ""
+                DOCUMENTSUI_AUTHORITY -> ""
                 // Include the authority to reduce ambiguity when this isn't a SAF URI provided by
                 // Android's local filesystem document provider
                 else -> "[$authority] "

--- a/app/src/main/java/com/chiller3/basicsync/settings/ConflictsActivity.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/ConflictsActivity.kt
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2024-2026 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.basicsync.settings
+
+import com.chiller3.basicsync.PreferenceBaseActivity
+import com.chiller3.basicsync.PreferenceBaseFragment
+import com.chiller3.basicsync.R
+
+class ConflictsActivity : PreferenceBaseActivity() {
+    override val titleResId: Int = R.string.pref_conflicts_name
+
+    override val showUpButton: Boolean = true
+
+    override fun createFragment(): PreferenceBaseFragment = ConflictsFragment()
+}

--- a/app/src/main/java/com/chiller3/basicsync/settings/ConflictsFragment.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/ConflictsFragment.kt
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.basicsync.settings
+
+import android.content.Intent
+import android.os.Bundle
+import android.provider.DocumentsContract
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.preference.Preference
+import androidx.preference.get
+import androidx.preference.size
+import com.chiller3.basicsync.PreferenceBaseFragment
+import com.chiller3.basicsync.R
+import com.chiller3.basicsync.extension.DOCUMENTSUI_AUTHORITY
+import com.chiller3.basicsync.extension.EXTERNAL_DIR
+import com.chiller3.basicsync.extension.expandTilde
+import com.chiller3.basicsync.extension.shortenTilde
+import kotlinx.coroutines.launch
+import java.io.File
+
+class ConflictsFragment : PreferenceBaseFragment(), Preference.OnPreferenceClickListener {
+    companion object {
+        const val PREFIX = "conflict_"
+    }
+
+    private val viewModel: ConflictsViewModel by viewModels()
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.preferences_conflicts, rootKey)
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.conflicts.collect { conflicts ->
+                    if (conflicts == null) {
+                        // Still loading.
+                        return@collect
+                    } else if (conflicts.isEmpty()) {
+                        // All conflicts were resolved.
+                        requireActivity().finish()
+                        return@collect
+                    }
+
+                    updateDynamicPrefs(conflicts)
+                }
+            }
+        }
+    }
+
+    private fun updateDynamicPrefs(conflicts: List<String>) {
+        val context = requireContext()
+
+        for (i in (0 until preferenceScreen.size).reversed()) {
+            val p = preferenceScreen[i]
+
+            if (p.key.startsWith(PREFIX)) {
+                preferenceScreen.removePreference(p)
+            }
+        }
+
+        for (conflict in conflicts) {
+            val expanded = File(conflict).expandTilde()
+            val shortened = expanded.shortenTilde()
+            val relPath = expanded.relativeTo(EXTERNAL_DIR)
+
+            val p = Preference(context).apply {
+                key = PREFIX + relPath
+                isPersistent = false
+                title = shortened.toString()
+                isIconSpaceReserved = false
+                onPreferenceClickListener = this@ConflictsFragment
+            }
+
+            preferenceScreen.addPreference(p)
+        }
+    }
+
+    override fun onPreferenceClick(preference: Preference): Boolean {
+        when {
+            preference.key.startsWith(PREFIX) -> {
+                val relPath = preference.key.substring(PREFIX.length)
+                val intent = Intent(Intent.ACTION_VIEW).apply {
+                    val uri = DocumentsContract.buildDocumentUri(
+                        DOCUMENTSUI_AUTHORITY,
+                        "primary:$relPath",
+                    )
+                    setDataAndType(uri, "vnd.android.document/directory")
+                }
+
+                startActivity(intent)
+
+                return true
+            }
+        }
+
+        return false
+    }
+}

--- a/app/src/main/java/com/chiller3/basicsync/settings/ConflictsViewModel.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/ConflictsViewModel.kt
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.basicsync.settings
+
+import android.app.Application
+
+class ConflictsViewModel(application: Application) : ServiceBaseViewModel(application)

--- a/app/src/main/java/com/chiller3/basicsync/settings/ServiceBaseViewModel.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/ServiceBaseViewModel.kt
@@ -26,6 +26,9 @@ abstract class ServiceBaseViewModel(application: Application) : AndroidViewModel
     private val _guiInfo = MutableStateFlow<SyncthingService.GuiInfo?>(null)
     val guiInfo = _guiInfo.asStateFlow()
 
+    private val _conflicts = MutableStateFlow<List<String>?>(null)
+    val conflicts = _conflicts.asStateFlow()
+
     init {
         val context = getApplication<Application>()
 
@@ -70,4 +73,8 @@ abstract class ServiceBaseViewModel(application: Application) : AndroidViewModel
         preRunAction: SyncthingService.PreRunAction,
         exception: Exception?,
     ) {}
+
+    override fun onConflictsUpdated(conflicts: List<String>) {
+        _conflicts.update { conflicts }
+    }
 }

--- a/app/src/main/java/com/chiller3/basicsync/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/SettingsFragment.kt
@@ -80,6 +80,7 @@ class SettingsFragment : PreferenceBaseFragment(), FragmentResultListener,
     private lateinit var prefAllowNotifications: Preference
     private lateinit var prefLocalStorageAccess: Preference
     private lateinit var prefDisableAppHibernation: Preference
+    private lateinit var prefConflicts: Preference
     private lateinit var prefOpenWebUi: Preference
     private lateinit var prefImportConfiguration: Preference
     private lateinit var prefExportConfiguration: Preference
@@ -164,6 +165,9 @@ class SettingsFragment : PreferenceBaseFragment(), FragmentResultListener,
         prefDisableAppHibernation = findPreference(Preferences.PREF_DISABLE_APP_HIBERNATION)!!
         prefDisableAppHibernation.onPreferenceClickListener = this
 
+        prefConflicts = findPreference(Preferences.PREF_CONFLICTS)!!
+        prefConflicts.onPreferenceClickListener = this
+
         prefOpenWebUi = findPreference(Preferences.PREF_OPEN_WEB_UI)!!
         prefOpenWebUi.onPreferenceClickListener = this
 
@@ -246,6 +250,21 @@ class SettingsFragment : PreferenceBaseFragment(), FragmentResultListener,
                             }
                         }
                     }
+                }
+            }
+        }
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.CREATED) {
+                viewModel.conflicts.collect { conflicts ->
+                    val numConflicts = conflicts?.size ?: 0
+
+                    prefConflicts.isVisible = numConflicts > 0
+                    prefConflicts.summary = resources.getQuantityString(
+                        R.plurals.pref_conflicts_desc,
+                        numConflicts,
+                        numConflicts,
+                    )
                 }
             }
         }
@@ -438,6 +457,10 @@ class SettingsFragment : PreferenceBaseFragment(), FragmentResultListener,
 
     override fun onPreferenceClick(preference: Preference): Boolean {
         when (preference) {
+            prefConflicts -> {
+                startActivity(Intent(requireContext(), ConflictsActivity::class.java))
+                return true
+            }
             prefOpenWebUi -> {
                 startActivity(Intent(requireContext(), WebUiActivity::class.java))
                 return true

--- a/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
+++ b/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
@@ -222,6 +222,19 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
 
     @GuardedBy("stateLock")
     private var syncthingApp: SyncthingApp? = null
+    @GuardedBy("stateLock")
+    private var syncthingConflicts = emptyList<String>()
+        set(conflicts) {
+            if (field != conflicts) {
+                field = conflicts
+
+                for (listener in listeners) {
+                    listener.onConflictsUpdated(conflicts)
+                }
+
+                notifications.sendOrClearConflictsNotification(conflicts)
+            }
+        }
 
     private val isResumed: Boolean
         @GuardedBy("stateLock")
@@ -503,7 +516,7 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
     }
 
     @WorkerThread
-    override fun onSyncthingStart(app: SyncthingApp) {
+    override fun onSyncthingStarted(app: SyncthingApp) {
         Log.i(TAG, "Syncthing successfully started")
 
         synchronized(stateLock) {
@@ -514,13 +527,30 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
     }
 
     @WorkerThread
-    override fun onSyncthingStop(app: SyncthingApp) {
-        Log.i(TAG, "Syncthing is about to stop")
+    override fun onSyncthingStopped(app: SyncthingApp) {
+        Log.i(TAG, "Syncthing successfully stopped")
 
         synchronized(stateLock) {
+            syncthingConflicts = emptyList()
             syncthingApp = null
 
             stateChanged()
+        }
+    }
+
+    @WorkerThread
+    override fun onConflictsUpdated(paths0Sep: String) {
+        val paths = if (paths0Sep.isEmpty()) {
+            emptyList()
+        } else {
+            mutableListOf<String>().apply {
+                paths0Sep.splitToSequence('\u0000').toCollection(this)
+                sort()
+            }
+        }
+
+        synchronized(stateLock) {
+            syncthingConflicts = paths
         }
     }
 
@@ -557,6 +587,8 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
         fun onRunStateChanged(state: ServiceState, guiInfo: GuiInfo?)
 
         fun onPreRunActionResult(preRunAction: PreRunAction, exception: Exception?)
+
+        fun onConflictsUpdated(conflicts: List<String>)
     }
 
     inner class ServiceBinder : Binder() {
@@ -569,6 +601,7 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
                 }
 
                 listener.onRunStateChanged(lastServiceState!!, guiInfo)
+                listener.onConflictsUpdated(syncthingConflicts)
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,6 +37,13 @@
     <string name="pref_open_web_ui_name">Open web UI</string>
     <!-- Description for the preference to open Syncthing's web UI. -->
     <string name="pref_open_web_ui_desc">Open Syncthing\'s web configuration interface.</string>
+    <!-- Title for the preference to open the list of sync conflicts. -->
+    <string name="pref_conflicts_name">Sync conflicts</string>
+    <!-- Description for the preference to open the list of sync conflicts. -->
+    <plurals name="pref_conflicts_desc">
+        <item quantity="one">%d file encountered a conflict during syncing.</item>
+        <item quantity="other">%d files encountered conflicts during syncing.</item>
+    </plurals>
     <!-- Title for the preference to import a Syncthing configuration backup. -->
     <string name="pref_import_configuration_name">Import configuration</string>
     <!-- Description for the preference to import an existing Syncthing configuration backup from a zip file. -->
@@ -85,6 +92,9 @@
     <string name="pref_save_logs_name">Save logs</string>
     <!-- Description for the debug preference that saves logs to a file. -->
     <string name="pref_save_logs_desc">Save logcat logs to a file.</string>
+
+    <!-- Description explaining the list of sync conflicts and what can be done with them. -->
+    <string name="pref_conflicts_info">The following files encountered conflicts during syncing and need to be resolved manually. Select a file to open its parent directory in the system file manager.</string>
 
     <!-- Section header for preferences that control which type of networks (metered, Wi-Fi, cellular, etc.) that Syncthing is allowed to sync on. -->
     <string name="pref_header_allowed_network_types">Allowed network types</string>
@@ -193,6 +203,10 @@
     <string name="notification_channel_failure_name">Failure alerts</string>
     <!-- Description of the Android notification channel for notifications about errors. -->
     <string name="notification_channel_failure_desc">Alerts for errors when starting Syncthing</string>
+    <!-- Name of the Android notification channel for notifications about sync conflicts. -->
+    <string name="notification_channel_conflicts_name">Sync conflicts</string>
+    <!-- Description of the Android notification channel for notifications about sync conflicts. -->
+    <string name="notification_channel_conflicts_desc">Alerts for conflicts encountered during syncing</string>
     <!-- Status text indicating that Syncthing is running and ready to sync. -->
     <string name="notification_persistent_running_title">Syncthing is running</string>
     <!-- Status text indicating that Syncthing is not running at all (not just paused). -->
@@ -213,6 +227,11 @@
     <string name="notification_failure_run_title">Failed to run Syncthing</string>
     <!-- Message shown in the notification when Syncthing failed to start up. -->
     <string name="notification_failure_run_message">Syncthing failed to run properly. To prevent a restart loop, Syncthing has been stopped and placed in manual mode.</string>
+    <!-- Title of the notification shown when a sync conflict is detected. -->
+    <plurals name="notification_conflicts_title">
+        <item quantity="one">%d sync conflict found</item>
+        <item quantity="other">%d sync conflicts found</item>
+    </plurals>
     <!-- Button shown in the background notification to switch from manual mode to auto mode. -->
     <string name="notification_action_auto_mode">Auto mode</string>
     <!-- Button shown in the background notification to switch from auto mode to manual mode. -->

--- a/app/src/main/res/xml/preferences_conflicts.xml
+++ b/app/src/main/res/xml/preferences_conflicts.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    SPDX-FileCopyrightText: 2026 Andrew Gunnerson
+    SPDX-License-Identifier: GPL-3.0-only
+-->
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+    <Preference
+        app:key="info_conflicts"
+        app:persistent="false"
+        app:summary="@string/pref_conflicts_info"
+        app:iconSpaceReserved="false" />
+</PreferenceScreen>

--- a/app/src/main/res/xml/preferences_root.xml
+++ b/app/src/main/res/xml/preferences_root.xml
@@ -44,6 +44,12 @@
         app:iconSpaceReserved="false">
 
         <Preference
+            app:key="conflicts"
+            app:persistent="false"
+            app:title="@string/pref_conflicts_name"
+            app:iconSpaceReserved="false" />
+
+        <Preference
             app:key="open_web_ui"
             app:persistent="false"
             app:title="@string/pref_open_web_ui_name"

--- a/stbridge/stbridge.go
+++ b/stbridge/stbridge.go
@@ -15,6 +15,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"iter"
 	"log"
 	"log/slog"
 	"net"
@@ -35,6 +36,7 @@ import (
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/locations"
+	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/rand"
 	"github.com/syncthing/syncthing/lib/svcutil"
 	"github.com/syncthing/syncthing/lib/syncthing"
@@ -277,9 +279,171 @@ func (app *SyncthingApp) GuiTlsCert() []byte {
 }
 
 type SyncthingStatusReceiver interface {
-	OnSyncthingStart(app *SyncthingApp)
+	OnSyncthingStarted(app *SyncthingApp)
 
-	OnSyncthingStop(app *SyncthingApp)
+	OnSyncthingStopped(app *SyncthingApp)
+
+	// Can be sent before OnSyncthingStarted, but not after OnSyncthingStopped.
+	// The list of paths is separated by a '\0' byte because gomobile does not
+	// support passing a list of strings to the JVM. This works for arbitrary
+	// paths on Linux.
+	OnConflictsUpdated(paths0Sep string)
+}
+
+// db.DB is internal, so it's unnameable and we can't create a function that
+// accepts one. We only need the AllLocalFiles() function though, so just pass
+// that as a function pointer instead.
+type allLocalFilesFunc func(
+	folder string,
+	device protocol.DeviceID,
+) (iter.Seq[protocol.FileInfo], func() error)
+
+func isConflict(name string) bool {
+	return strings.Contains(filepath.Base(name), ".sync-conflict-")
+}
+
+func dispatchConflicts(
+	folderConflicts map[string]map[string]struct{},
+	folderToPath map[string]string,
+	receiver SyncthingStatusReceiver,
+) {
+	var paths0Sep strings.Builder
+
+	for folder, names := range folderConflicts {
+		folderPath := folderToPath[folder]
+
+		for name, _ := range names {
+			if paths0Sep.Len() > 0 {
+				paths0Sep.WriteRune('\u0000')
+			}
+			paths0Sep.WriteString(filepath.Join(folderPath, name))
+		}
+	}
+
+	receiver.OnConflictsUpdated(paths0Sep.String())
+}
+
+func eventLoop(
+	ctx context.Context,
+	stopped chan struct{},
+	evLogger events.Logger,
+	folderConflicts map[string]map[string]struct{},
+	folderToPath map[string]string,
+	receiver SyncthingStatusReceiver,
+) {
+	defer close(stopped)
+
+	sub := evLogger.Subscribe(
+		events.LocalChangeDetected |
+			events.RemoteChangeDetected |
+			events.ConfigSaved,
+	)
+	defer sub.Unsubscribe()
+
+	for {
+		select {
+		case evt := <-sub.C():
+			switch evt.Type {
+			// We do not use LocalIndexUpdated because it does not distinguish
+			// between added/modified and removed.
+			case events.LocalChangeDetected, events.RemoteChangeDetected:
+				data := evt.Data.(map[string]string)
+				folderID := data["folder"]
+				path := data["path"]
+
+				if !isConflict(path) {
+					continue
+				}
+
+				if data["action"] == "deleted" {
+					delete(folderConflicts[folderID], path)
+				} else {
+					if _, ok := folderConflicts[folderID]; !ok {
+						folderConflicts[folderID] = map[string]struct{}{}
+					}
+					folderConflicts[folderID][path] = struct{}{}
+				}
+
+				dispatchConflicts(folderConflicts, folderToPath, receiver)
+
+			// When a folder is deleted, we need to manually clear out the
+			// corresponding conflicts because we will not receive deletion
+			// events for them.
+			case events.ConfigSaved:
+				cfg := evt.Data.(config.Configuration)
+
+				clear(folderToPath)
+
+				for _, folder := range cfg.Folders {
+					// Never fails on Android.
+					folderToPath[folder.ID], _ = fs.ExpandTilde(folder.Path)
+				}
+
+				for key := range folderConflicts {
+					if _, ok := folderToPath[key]; !ok {
+						delete(folderConflicts, key)
+					}
+				}
+
+				dispatchConflicts(folderConflicts, folderToPath, receiver)
+
+			default:
+				// Ignore.
+			}
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func startEventLoop(
+	ctx context.Context,
+	stopped chan struct{},
+	evLogger events.Logger,
+	cfg config.Wrapper,
+	allLocalFiles allLocalFilesFunc,
+	receiver SyncthingStatusReceiver,
+) error {
+	folderConflicts := map[string]map[string]struct{}{}
+	folderToPath := map[string]string{}
+
+	// Find the initial set of conflicts from the database before starting the
+	// service. Any newly added or deleted conflicts will be reported by the
+	// service via events, so we should always have a consistent view of the
+	// world.
+	for _, folder := range cfg.FolderList() {
+		dbFiles, errFn := allLocalFiles(folder.ID, protocol.LocalDeviceID)
+		for dbFile := range dbFiles {
+			if !isConflict(dbFile.Name) || dbFile.Deleted {
+				continue
+			}
+
+			if _, ok := folderConflicts[folder.ID]; !ok {
+				folderConflicts[folder.ID] = map[string]struct{}{}
+			}
+			folderConflicts[folder.ID][dbFile.Name] = struct{}{}
+		}
+		if err := errFn(); err != nil {
+			return fmt.Errorf("failed to query database for: %q: %w", folder.ID, err)
+		}
+
+		// Never fails on Android.
+		folderToPath[folder.ID], _ = fs.ExpandTilde(folder.Path)
+	}
+
+	dispatchConflicts(folderConflicts, folderToPath, receiver)
+
+	go eventLoop(
+		ctx,
+		stopped,
+		evLogger,
+		folderConflicts,
+		folderToPath,
+		receiver,
+	)
+
+	return nil
 }
 
 type SyncthingStartupConfig struct {
@@ -417,7 +581,13 @@ func Run(startup *SyncthingStartupConfig) error {
 		return fmt.Errorf("failed to initialize syncthing: %w", err)
 	}
 
-	if err := app.Start(); err != nil {
+	eventLoopStopped := make(chan struct{})
+	if err = startEventLoop(ctx, eventLoopStopped, evLogger, cfg,
+		sdb.AllLocalFiles, startup.Receiver); err != nil {
+		return fmt.Errorf("failed to start event loop: %w", err)
+	}
+
+	if err = app.Start(); err != nil {
 		return fmt.Errorf("failed to start syncthing: %w", app.Error())
 	}
 
@@ -434,11 +604,15 @@ func Run(startup *SyncthingStartupConfig) error {
 		guiCert: guiCert,
 	}
 
-	startup.Receiver.OnSyncthingStart(appWrapper)
+	startup.Receiver.OnSyncthingStarted(appWrapper)
 
 	status := app.Wait()
 
-	startup.Receiver.OnSyncthingStop(appWrapper)
+	// Ensure we don't send any more events after OnSyncthingStop().
+	cancel()
+	<-eventLoopStopped
+
+	startup.Receiver.OnSyncthingStopped(appWrapper)
 
 	if status == svcutil.ExitError {
 		return fmt.Errorf("failed when stopping syncthing: %w", app.Error())


### PR DESCRIPTION
Syncthing does not natively have a way to report conflicts. Other apps work around this by scanning the filesystem for files matching the sync conflict filename pattern. However, since we integrate Syncthing as a library, we can do a bit better and use its database instead. Prior to starting the service, the database will be used to build the initial state of the conflicts. Afterwards, the event logger will be used to keep the state up to date.

The conflict handling is limited to just reporting. When a conflict is detected, a notification will be shown, which the user can tap to show the full list of sync conflicts. To keep the code simple, there is intentionally no way to open/move/delete/etc. these files. Instead, tapping on them will open the parent directory in DocumentsUI.

Fixes: #79