### PR TITLE
Add optional exit button to persistent notification

### DIFF
--- a/app/src/main/java/com/chiller3/basicsync/Notifications.kt
+++ b/app/src/main/java/com/chiller3/basicsync/Notifications.kt
@@ -113,6 +113,7 @@ class Notifications(private val context: Context) {
                     SyncthingService.ACTION_MANUAL_MODE -> R.string.notification_action_manual_mode
                     SyncthingService.ACTION_START -> R.string.notification_action_start
                     SyncthingService.ACTION_STOP -> R.string.notification_action_stop
+                    SyncthingService.ACTION_EXIT -> R.string.notification_action_exit
                     else -> throw IllegalArgumentException("Invalid action: $action")
                 }
 

--- a/app/src/main/java/com/chiller3/basicsync/Preferences.kt
+++ b/app/src/main/java/com/chiller3/basicsync/Preferences.kt
@@ -25,6 +25,7 @@ class Preferences(context: Context) {
         const val PREF_SYNC_SCHEDULE = "sync_schedule"
         const val PREF_KEEP_ALIVE = "keep_alive"
         const val PREF_REMOTE_CONTROL = "remote_control"
+        const val PREF_SHOW_EXIT = "show_exit"
 
         // Main UI actions only.
         const val PREF_INHIBIT_BATTERY_OPT = "inhibit_battery_opt"
@@ -97,6 +98,10 @@ class Preferences(context: Context) {
     var remoteControl: Boolean
         get() = prefs.getBoolean(PREF_REMOTE_CONTROL, false)
         set(enabled) = prefs.edit { putBoolean(PREF_REMOTE_CONTROL, enabled) }
+
+    var showExit: Boolean
+        get() = prefs.getBoolean(PREF_SHOW_EXIT, false)
+        set(enabled) = prefs.edit { putBoolean(PREF_SHOW_EXIT, enabled) }
 
     var requireUnmeteredNetwork: Boolean
         get() = prefs.getBoolean(PREF_REQUIRE_UNMETERED_NETWORK, true)

--- a/app/src/main/java/com/chiller3/basicsync/settings/ConflictsFragment.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/ConflictsFragment.kt
@@ -36,6 +36,14 @@ class ConflictsFragment : PreferenceBaseFragment(), Preference.OnPreferenceClick
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.exitRequested.collect {
+                    requireActivity().finishAffinity()
+                }
+            }
+        }
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.conflicts.collect { conflicts ->
                     if (conflicts == null) {
                         // Still loading.

--- a/app/src/main/java/com/chiller3/basicsync/settings/ServiceBaseViewModel.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/ServiceBaseViewModel.kt
@@ -12,13 +12,18 @@ import android.content.ServiceConnection
 import android.os.IBinder
 import androidx.lifecycle.AndroidViewModel
 import com.chiller3.basicsync.syncthing.SyncthingService
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 
 abstract class ServiceBaseViewModel(application: Application) : AndroidViewModel(application),
     ServiceConnection, SyncthingService.ServiceListener {
     protected var binder: SyncthingService.ServiceBinder? = null
+
+    private val _exitRequested = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val exitRequested = _exitRequested.asSharedFlow()
 
     private val _serviceState = MutableStateFlow<SyncthingService.ServiceState?>(null)
     val serviceState = _serviceState.asStateFlow()
@@ -59,6 +64,11 @@ abstract class ServiceBaseViewModel(application: Application) : AndroidViewModel
     private fun onBinderGone() {
         binder?.unregisterListener(this)
         binder = null
+        _exitRequested.tryEmit(Unit)
+    }
+
+    override fun onExitRequested() {
+        onBinderGone()
     }
 
     override fun onRunStateChanged(

--- a/app/src/main/java/com/chiller3/basicsync/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/SettingsFragment.kt
@@ -209,6 +209,14 @@ class SettingsFragment : PreferenceBaseFragment(), FragmentResultListener,
         refreshDebugPrefs()
 
         lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.exitRequested.collect {
+                    requireActivity().finishAffinity()
+                }
+            }
+        }
+
+        lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.CREATED) {
                 viewModel.serviceState.collect { state ->
                     val runState = state?.runState

--- a/app/src/main/java/com/chiller3/basicsync/settings/WebUiActivity.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/WebUiActivity.kt
@@ -206,6 +206,14 @@ class WebUiActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.CREATED) {
+                viewModel.exitRequested.collect {
+                    finishAffinity()
+                }
+            }
+        }
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.CREATED) {
                 viewModel.serviceState.collect {
                     if (it?.runState?.webUiAvailable == false) {
                         finish()

--- a/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
+++ b/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
@@ -37,6 +37,7 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
             Preferences.PREF_MANUAL_MODE,
             Preferences.PREF_MANUAL_SHOULD_RUN,
             Preferences.PREF_KEEP_ALIVE,
+            Preferences.PREF_SHOW_EXIT,
         )
 
         val ACTION_AUTO_MODE = "${SyncthingService::class.java.canonicalName}.auto_mode"
@@ -44,6 +45,7 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
         val ACTION_START = "${SyncthingService::class.java.canonicalName}.start"
         val ACTION_STOP = "${SyncthingService::class.java.canonicalName}.stop"
         val ACTION_RENOTIFY = "${SyncthingService::class.java.canonicalName}.renotify"
+        val ACTION_EXIT = "${SyncthingService::class.java.canonicalName}.exit"
 
         fun createIntent(context: Context, action: String?) =
             Intent(context, SyncthingService::class.java).apply {
@@ -79,6 +81,7 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
         private val isResumed: Boolean,
         private val manualMode: Boolean,
         private val preRunAction: PreRunAction?,
+        private val showExit: Boolean,
     ) {
         private val shouldResume: Boolean
             get() = blockedReasons.isEmpty()
@@ -132,6 +135,10 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
                         }
                     } else {
                         add(ACTION_MANUAL_MODE)
+                    }
+
+                    if (showExit) {
+                        add(ACTION_EXIT)
                     }
                 }
             }
@@ -228,9 +235,7 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
             if (field != conflicts) {
                 field = conflicts
 
-                for (listener in listeners) {
-                    listener.onConflictsUpdated(conflicts)
-                }
+                allListeners { it.onConflictsUpdated(conflicts) }
 
                 notifications.sendOrClearConflictsNotification(conflicts)
             }
@@ -262,6 +267,11 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
     @GuardedBy("stateLock")
     private val listeners = HashSet<ServiceListener>()
 
+    @GuardedBy("stateLock")
+    private fun allListeners(block: (ServiceListener) -> Unit) {
+        HashSet(listeners).forEach(block)
+    }
+
     override fun onCreate() {
         super.onCreate()
 
@@ -285,6 +295,13 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
             shouldThreadRun = false
         }
         stateChanged()
+
+        // This should be quick.
+        runnerThread.join()
+
+        synchronized(stateLock) {
+            listeners.clear()
+        }
 
         prefs.unregisterListener(this)
 
@@ -318,6 +335,12 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
             }
             ACTION_RENOTIFY -> synchronized(stateLock) {
                 forceShowNotification = true
+            }
+            ACTION_EXIT -> {
+                allListeners { it.onExitRequested() }
+
+                stopSelf()
+                return START_NOT_STICKY
             }
             null -> {}
             else -> Log.w(TAG, "Ignoring unrecognized intent: $intent")
@@ -376,6 +399,7 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
                 isResumed = isResumed,
                 manualMode = prefs.isManualMode,
                 preRunAction = currentPreRunAction,
+                showExit = prefs.showExit,
             )
 
             val wasChanged = notificationState != lastServiceState
@@ -386,9 +410,7 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
                 if (wasChanged) {
                     val guiInfo = guiInfo
 
-                    for (listener in listeners) {
-                        listener.onRunStateChanged(notificationState, guiInfo)
-                    }
+                    allListeners { it.onRunStateChanged(notificationState, guiInfo) }
                 }
 
                 val notification = notifications.createPersistentNotification(notificationState)
@@ -479,9 +501,7 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
                     }
 
                     synchronized(stateLock) {
-                        for (listener in listeners) {
-                            listener.onPreRunActionResult(action, exception)
-                        }
+                        allListeners { it.onPreRunActionResult(action, exception) }
 
                         currentPreRunAction = null
                         stateChanged()
@@ -584,6 +604,8 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
     }
 
     interface ServiceListener {
+        fun onExitRequested()
+
         fun onRunStateChanged(state: ServiceState, guiInfo: GuiInfo?)
 
         fun onPreRunActionResult(preRunAction: PreRunAction, exception: Exception?)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,6 +86,10 @@
     <string name="pref_remote_control_name">Allow remote control</string>
     <!-- Description for the preference that allows external apps to control when Syncthing runs. -->
     <string name="pref_remote_control_desc">Allow external apps to switch to auto mode or manually start and stop Syncthing.</string>
+    <!-- Title for the preference to show an exit button in the persistent notification. -->
+    <string name="pref_show_exit_name">Show Exit button</string>
+    <!-- Description for the preference to show an exit button in the persistent notification. -->
+    <string name="pref_show_exit_desc">Show an Exit button in the persistent notification. The app will automatically start again after a reboot or when receiving a remote control command.</string>
     <!-- Title for the preference that shows the version number. The description is two lines: the first line is BasicSync's version and the second line in Syncthing's version. -->
     <string name="pref_version_name">Version</string>
     <!-- Title for the debug preference that saves logs to a file. -->
@@ -195,9 +199,9 @@
     <!-- Tooltip shown in Syncthing's web UI for scanning a QR code when adding a new device. Keep as short as possible. -->
     <string name="web_ui_scan_qr_code">Scan QR code</string>
 
-    <!-- Name of the Android notification channel for the background notification that is always shown. -->
+    <!-- Name of the Android notification channel for the persistent notification that is always shown. -->
     <string name="notification_channel_persistent_name">Background services</string>
-    <!-- Description of the Android notification channel for the background notification that is always shown. -->
+    <!-- Description of the Android notification channel for the persistent notification that is always shown. -->
     <string name="notification_channel_persistent_desc">Keeps Syncthing running in the background</string>
     <!-- Name of the Android notification channel for notifications about errors. -->
     <string name="notification_channel_failure_name">Failure alerts</string>
@@ -232,14 +236,16 @@
         <item quantity="one">%d sync conflict found</item>
         <item quantity="other">%d sync conflicts found</item>
     </plurals>
-    <!-- Button shown in the background notification to switch from manual mode to auto mode. -->
+    <!-- Button shown in the persistent notification to switch from manual mode to auto mode. -->
     <string name="notification_action_auto_mode">Auto mode</string>
-    <!-- Button shown in the background notification to switch from auto mode to manual mode. -->
+    <!-- Button shown in the persistent notification to switch from auto mode to manual mode. -->
     <string name="notification_action_manual_mode">Manual mode</string>
-    <!-- Button shown in the background notification to start Syncthing. This is only shown in manual mode. -->
+    <!-- Button shown in the persistent notification to start Syncthing. This is only shown in manual mode. -->
     <string name="notification_action_start">Start</string>
-    <!-- Button shown in the background notification to stop Syncthing. This is only shown in manual mode. This currently does not distinguish between stopping and pausing. The text should represent "stop". -->
+    <!-- Button shown in the persistent notification to stop Syncthing. This is only shown in manual mode. This currently does not distinguish between stopping and pausing. The text should represent "stop". -->
     <string name="notification_action_stop">Stop</string>
+    <!-- Button shown in the persistent notification to exit the app entirely until the next reboot or the user starts it again. -->
+    <string name="notification_action_exit">Exit</string>
 
     <!-- Syncing is blocked because local storage permissions have not been granted. -->
     <string name="blocked_reason_no_storage_permissions">• Storage permissions denied</string>

--- a/app/src/main/res/xml/preferences_root.xml
+++ b/app/src/main/res/xml/preferences_root.xml
@@ -137,6 +137,12 @@
             app:title="@string/pref_remote_control_name"
             app:summary="@string/pref_remote_control_desc"
             app:iconSpaceReserved="false" />
+
+        <SwitchPreferenceCompat
+            app:key="show_exit"
+            app:title="@string/pref_show_exit_name"
+            app:summary="@string/pref_show_exit_desc"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
The option is disabled by default. When enabled, an exit button will be shown in the persistent notification. This will safely exit the service and all open activities. The service will restart if the user opens any activity again, if the device is rebooted, or if a remote control command is received.

Closes: #105