### PR TITLE
Add optional idle timer to stop Syncthing early

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -99,6 +99,10 @@
             android:name=".settings.QrScannerActivity"
             android:exported="false" />
 
+        <activity
+            android:name=".settings.SyncScheduleActivity"
+            android:exported="false" />
+
         <!--
             These config changes are ignored because WebView has no way of persisting the JavaScript
             and DOM states. Only the history is preserved.

--- a/app/src/main/java/com/chiller3/basicsync/Preferences.kt
+++ b/app/src/main/java/com/chiller3/basicsync/Preferences.kt
@@ -9,6 +9,8 @@ import android.content.Context
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
+import kotlin.math.max
+import kotlin.math.min
 
 class Preferences(context: Context) {
     companion object {
@@ -22,8 +24,6 @@ class Preferences(context: Context) {
         const val PREF_MIN_BATTERY_LEVEL = "min_battery_level"
         const val PREF_RESPECT_BATTERY_SAVER = "respect_battery_saver"
         const val PREF_RESPECT_AUTO_SYNC_DATA = "respect_auto_sync_data"
-        const val PREF_SYNC_SCHEDULE = "sync_schedule"
-        const val PREF_SYNC_SCHEDULE_BATTERY_ONLY = "sync_schedule_battery_only"
         const val PREF_KEEP_ALIVE = "keep_alive"
         const val PREF_REMOTE_CONTROL = "remote_control"
         const val PREF_SHOW_EXIT = "show_exit"
@@ -39,6 +39,7 @@ class Preferences(context: Context) {
         const val PREF_EXPORT_CONFIGURATION = "export_configuration"
         const val PREF_SERVICE_STATUS = "service_status"
         const val PREF_NETWORK_CONDITIONS = "network_conditions"
+        const val PREF_SYNC_SCHEDULE_SETTINGS = "sync_schedule_settings"
         const val PREF_VERSION = "version"
         const val PREF_SAVE_LOGS = "save_logs"
 
@@ -48,6 +49,7 @@ class Preferences(context: Context) {
         const val PREF_MANUAL_SHOULD_RUN = "manual_should_run"
         const val PREF_SCHEDULE_CYCLE_MS = "schedule_cycle_ms"
         const val PREF_SCHEDULE_SYNC_MS = "schedule_sync_ms"
+        const val PREF_SCHEDULE_IDLE_MS = "schedule_idle_ms"
 
         // Network condition preferences.
         const val CATEGORY_ALLOWED_WIFI_NETWORKS = "allowed_wifi_networks"
@@ -61,6 +63,11 @@ class Preferences(context: Context) {
         const val PREF_ALLOW_BACKGROUND_LOCATION = "allow_background_location"
         const val PREF_ADD_NEW_NETWORK = "add_new_network"
         const val PREF_ALLOWED_WIFI_NETWORKS = "allowed_wifi_networks"
+
+        // Sync schedule preferences.
+        const val PREF_SYNC_SCHEDULE = "sync_schedule"
+        const val PREF_SYNC_SCHEDULE_IDLE = "sync_schedule_idle"
+        const val PREF_SYNC_SCHEDULE_BATTERY_ONLY = "sync_schedule_battery_only"
 
         // Legacy preferences.
         private const val PREF_REQUIRE_SUFFICIENT_BATTERY = "require_sufficient_battery"
@@ -132,6 +139,10 @@ class Preferences(context: Context) {
         get() = prefs.getBoolean(PREF_SYNC_SCHEDULE, false)
         set(enabled) = prefs.edit { putBoolean(PREF_SYNC_SCHEDULE, enabled) }
 
+    var syncScheduleIdle: Boolean
+        get() = prefs.getBoolean(PREF_SYNC_SCHEDULE_IDLE, false)
+        set(enabled) = prefs.edit { putBoolean(PREF_SYNC_SCHEDULE_IDLE, enabled) }
+
     var scheduleCycleMs: Int
         get() = prefs.getInt(PREF_SCHEDULE_CYCLE_MS, 60 * 60 * 1000)
         set(ms) = prefs.edit { putInt(PREF_SCHEDULE_CYCLE_MS, ms) }
@@ -139,6 +150,10 @@ class Preferences(context: Context) {
     var scheduleSyncMs: Int
         get() = prefs.getInt(PREF_SCHEDULE_SYNC_MS, 5 * 60 * 1000)
         set(ms) = prefs.edit { putInt(PREF_SCHEDULE_SYNC_MS, ms) }
+
+    var scheduleIdleMs: Int
+        get() = prefs.getInt(PREF_SCHEDULE_IDLE_MS, 3 * 60 * 1000)
+        set(ms) = prefs.edit { putInt(PREF_SCHEDULE_IDLE_MS, ms) }
 
     var syncScheduleBatteryOnly: Boolean
         get() = prefs.getBoolean(PREF_SYNC_SCHEDULE_BATTERY_ONLY, false)
@@ -163,6 +178,17 @@ class Preferences(context: Context) {
             }
 
             prefs.edit { remove(PREF_REQUIRE_SUFFICIENT_BATTERY) }
+        }
+
+        clampSyncScheduleDurations(true)
+    }
+
+    fun clampSyncScheduleDurations(preferCycleSync: Boolean) {
+        if (preferCycleSync) {
+            scheduleIdleMs = min(scheduleIdleMs, scheduleSyncMs)
+        } else {
+            scheduleCycleMs = max(scheduleCycleMs, scheduleIdleMs)
+            scheduleSyncMs = max(scheduleSyncMs, scheduleIdleMs)
         }
     }
 }

--- a/app/src/main/java/com/chiller3/basicsync/dialog/SyncScheduleIdleDialogFragment.kt
+++ b/app/src/main/java/com/chiller3/basicsync/dialog/SyncScheduleIdleDialogFragment.kt
@@ -17,51 +17,22 @@ import androidx.fragment.app.setFragmentResult
 import com.chiller3.basicsync.Preferences
 import com.chiller3.basicsync.R
 import com.chiller3.basicsync.databinding.DialogTextInputBinding
+import com.chiller3.basicsync.dialog.SyncScheduleDialogFragment.Companion.humanToMs
+import com.chiller3.basicsync.dialog.SyncScheduleDialogFragment.Companion.msToHuman
 import com.chiller3.basicsync.syncthing.DeviceStateTracker
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
-class SyncScheduleDialogFragment : DialogFragment() {
+class SyncScheduleIdleDialogFragment : DialogFragment() {
     companion object {
-        val TAG: String = SyncScheduleDialogFragment::class.java.simpleName
+        val TAG: String = SyncScheduleIdleDialogFragment::class.java.simpleName
 
         const val RESULT_SUCCESS = "success"
-
-        internal fun msToHuman(duration: Int): String =
-            if (duration % (60 * 60 * 1000) == 0) {
-                val hours = duration / 60 / 60 / 1000
-                "${hours}h"
-            } else if (duration % (60 * 1000) == 0) {
-                val minutes = duration / 60 / 1000
-                "${minutes}m"
-            } else {
-                val seconds = duration / 1000
-                "${seconds}s"
-            }
-
-        internal fun humanToMs(input: String): Int {
-            val multiplier = when (input.last()) {
-                'h' -> 60 * 60 * 1000
-                'm' -> 60 * 1000
-                's' -> 1000
-                else -> throw IllegalArgumentException("Unrecognized suffix in: $input")
-            }
-
-            val base = input.substring(0, input.length - 1).toInt()
-            if (base <= 0) {
-                throw IllegalArgumentException("Base value must be positive: $base")
-            } else if (base > Int.MAX_VALUE / multiplier) {
-                throw IllegalArgumentException("Duration too large as ms: $base * $multiplier")
-            }
-
-            return base * multiplier
-        }
     }
 
     private lateinit var prefs: Preferences
     private lateinit var binding: DialogTextInputBinding
     private var success: Boolean = false
-    private var cycleMs: Int? = null
-    private var syncMs: Int? = null
+    private var idleMs: Int? = null
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val context = requireContext()
@@ -71,25 +42,14 @@ class SyncScheduleDialogFragment : DialogFragment() {
         binding = DialogTextInputBinding.inflate(layoutInflater)
         binding.message.setText(R.string.dialog_sync_schedule_message)
 
-        binding.textLayout.setHint(R.string.dialog_sync_schedule_hint_cycle)
-        binding.confirmTextLayout.setHint(R.string.dialog_sync_schedule_hint_sync)
-        binding.confirmTextLayout.isVisible = true
+        binding.textLayout.setHint(R.string.dialog_sync_schedule_hint_idle)
+        binding.confirmTextLayout.isVisible = false
 
         val inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
         binding.text.inputType = inputType
-        binding.confirmText.inputType = inputType
 
         binding.text.addTextChangedListener {
-            cycleMs = try {
-                humanToMs(it.toString())
-            } catch (_: Exception) {
-                null
-            }
-
-            refreshOkButtonEnabledState()
-        }
-        binding.confirmText.addTextChangedListener {
-            syncMs = try {
+            idleMs = try {
                 humanToMs(it.toString())
             } catch (_: Exception) {
                 null
@@ -99,8 +59,7 @@ class SyncScheduleDialogFragment : DialogFragment() {
         }
 
         if (savedInstanceState == null) {
-            binding.text.setText(msToHuman(prefs.scheduleCycleMs))
-            binding.confirmText.setText(msToHuman(prefs.scheduleSyncMs))
+            binding.text.setText(msToHuman(prefs.scheduleIdleMs))
         }
 
         return MaterialAlertDialogBuilder(context)
@@ -122,21 +81,17 @@ class SyncScheduleDialogFragment : DialogFragment() {
         super.onDismiss(dialog)
 
         if (success) {
-            prefs.scheduleCycleMs = cycleMs!!
-            prefs.scheduleSyncMs = syncMs!!
-            prefs.clampSyncScheduleDurations(true)
+            prefs.scheduleIdleMs = idleMs!!
+            prefs.clampSyncScheduleDurations(false)
         }
 
         setFragmentResult(tag!!, Bundle().apply { putBoolean(RESULT_SUCCESS, success) })
     }
 
     private fun refreshOkButtonEnabledState() {
-        val cycleMs = cycleMs
-        val syncMs = syncMs
+        val idleMs = idleMs
 
         (dialog as AlertDialog?)?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled =
-            cycleMs != null && syncMs != null && syncMs < cycleMs
-                    && syncMs >= DeviceStateTracker.MINIMUM_SYNC_MS
-                    && cycleMs >= DeviceStateTracker.MINIMUM_CYCLE_MS
+            idleMs != null && idleMs >= DeviceStateTracker.MINIMUM_IDLE_MS
     }
 }

--- a/app/src/main/java/com/chiller3/basicsync/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/SettingsFragment.kt
@@ -37,7 +37,6 @@ import com.chiller3.basicsync.binding.stbridge.Stbridge
 import com.chiller3.basicsync.dialog.MessageDialogFragment
 import com.chiller3.basicsync.dialog.MinBatteryLevelDialogFragment
 import com.chiller3.basicsync.dialog.PasswordDialogFragment
-import com.chiller3.basicsync.dialog.SyncScheduleDialogFragment
 import com.chiller3.basicsync.extension.formattedString
 import com.chiller3.basicsync.syncthing.SyncthingService
 import com.chiller3.basicsync.view.LongClickablePreference
@@ -89,8 +88,7 @@ class SettingsFragment : PreferenceBaseFragment(), FragmentResultListener,
     private lateinit var prefAutoMode: SwitchPreferenceCompat
     private lateinit var prefNetworkConditions: Preference
     private lateinit var prefRunOnBattery: SplitSwitchPreference
-    private lateinit var prefSyncSchedule: SplitSwitchPreference
-    private lateinit var prefSyncScheduleBatteryOnly: SwitchPreferenceCompat
+    private lateinit var prefSyncScheduleSettings: Preference
     private lateinit var prefVersion: LongClickablePreference
     private lateinit var prefSaveLogs: Preference
 
@@ -191,10 +189,8 @@ class SettingsFragment : PreferenceBaseFragment(), FragmentResultListener,
         prefRunOnBattery = findPreference(Preferences.PREF_RUN_ON_BATTERY)!!
         prefRunOnBattery.onPreferenceClickListener = this
 
-        prefSyncSchedule = findPreference(Preferences.PREF_SYNC_SCHEDULE)!!
-        prefSyncSchedule.onPreferenceClickListener = this
-
-        prefSyncScheduleBatteryOnly = findPreference(Preferences.PREF_SYNC_SCHEDULE_BATTERY_ONLY)!!
+        prefSyncScheduleSettings = findPreference(Preferences.PREF_SYNC_SCHEDULE_SETTINGS)!!
+        prefSyncScheduleSettings.onPreferenceClickListener = this
 
         prefVersion = findPreference(Preferences.PREF_VERSION)!!
         prefVersion.onPreferenceClickListener = this
@@ -208,7 +204,6 @@ class SettingsFragment : PreferenceBaseFragment(), FragmentResultListener,
         refreshPermissions()
 
         refreshBattery()
-        refreshSchedule()
         refreshVersion()
         refreshDebugPrefs()
 
@@ -315,7 +310,6 @@ class SettingsFragment : PreferenceBaseFragment(), FragmentResultListener,
         for (key in arrayOf(
             TAG_IMPORT_EXPORT_PASSWORD,
             MinBatteryLevelDialogFragment.TAG,
-            SyncScheduleDialogFragment.TAG,
         )) {
             parentFragmentManager.setFragmentResultListener(key, this, this)
         }
@@ -401,30 +395,6 @@ class SettingsFragment : PreferenceBaseFragment(), FragmentResultListener,
 
         prefRunOnBattery.isVisible = hasBattery
         prefRunOnBattery.summary = getString(R.string.pref_run_on_battery_desc, prefs.minBatteryLevel)
-
-        prefSyncScheduleBatteryOnly.isVisible = hasBattery
-    }
-
-    private fun formatDurationMs(duration: Int): String =
-        if (duration % (60 * 60 * 1000) == 0) {
-            val hours = duration / 60 / 60 / 1000
-            resources.getQuantityString(R.plurals.duration_hours, hours, hours)
-        } else if (duration % (60 * 1000) == 0) {
-            val minutes = duration / 60 / 1000
-            resources.getQuantityString(R.plurals.duration_minutes, minutes, minutes)
-        } else {
-            val seconds = duration / 1000
-            resources.getQuantityString(R.plurals.duration_seconds, seconds, seconds)
-        }
-
-    private fun refreshSchedule() {
-        val cycleDuration = formatDurationMs(prefs.scheduleCycleMs)
-        val syncDuration = formatDurationMs(prefs.scheduleSyncMs)
-
-        prefSyncSchedule.summary =
-            getString(R.string.pref_sync_schedule_desc, cycleDuration, syncDuration)
-
-        prefSyncScheduleBatteryOnly.isEnabled = prefSyncSchedule.isChecked
     }
 
     private fun refreshVersion() {
@@ -461,11 +431,6 @@ class SettingsFragment : PreferenceBaseFragment(), FragmentResultListener,
             MinBatteryLevelDialogFragment.TAG -> {
                 if (bundle.getBoolean(MinBatteryLevelDialogFragment.RESULT_SUCCESS)) {
                     refreshBattery()
-                }
-            }
-            SyncScheduleDialogFragment.TAG -> {
-                if (bundle.getBoolean(SyncScheduleDialogFragment.RESULT_SUCCESS)) {
-                    refreshSchedule()
                 }
             }
         }
@@ -540,11 +505,8 @@ class SettingsFragment : PreferenceBaseFragment(), FragmentResultListener,
                 )
                 return true
             }
-            prefSyncSchedule -> {
-                SyncScheduleDialogFragment().show(
-                    parentFragmentManager.beginTransaction(),
-                    SyncScheduleDialogFragment.TAG,
-                )
+            prefSyncScheduleSettings -> {
+                startActivity(Intent(requireContext(), SyncScheduleActivity::class.java))
                 return true
             }
             prefVersion -> {
@@ -606,7 +568,6 @@ class SettingsFragment : PreferenceBaseFragment(), FragmentResultListener,
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
         when (key) {
             Preferences.PREF_MANUAL_MODE -> refreshService()
-            Preferences.PREF_SYNC_SCHEDULE -> refreshSchedule()
         }
     }
 

--- a/app/src/main/java/com/chiller3/basicsync/settings/SyncScheduleActivity.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/SyncScheduleActivity.kt
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.basicsync.settings
+
+import com.chiller3.basicsync.PreferenceBaseActivity
+import com.chiller3.basicsync.PreferenceBaseFragment
+import com.chiller3.basicsync.R
+
+class SyncScheduleActivity : PreferenceBaseActivity() {
+    override val titleResId: Int = R.string.pref_sync_schedule_settings_name
+
+    override val showUpButton: Boolean = true
+
+    override fun createFragment(): PreferenceBaseFragment = SyncScheduleFragment()
+}

--- a/app/src/main/java/com/chiller3/basicsync/settings/SyncScheduleFragment.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/SyncScheduleFragment.kt
@@ -1,0 +1,141 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.basicsync.settings
+
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.SharedPreferences
+import android.os.BatteryManager
+import android.os.Bundle
+import androidx.fragment.app.FragmentResultListener
+import androidx.preference.Preference
+import androidx.preference.SwitchPreferenceCompat
+import com.chiller3.basicsync.PreferenceBaseFragment
+import com.chiller3.basicsync.Preferences
+import com.chiller3.basicsync.R
+import com.chiller3.basicsync.dialog.SyncScheduleDialogFragment
+import com.chiller3.basicsync.dialog.SyncScheduleIdleDialogFragment
+import com.chiller3.basicsync.view.SplitSwitchPreference
+
+class SyncScheduleFragment : PreferenceBaseFragment(), FragmentResultListener,
+    Preference.OnPreferenceClickListener, SharedPreferences.OnSharedPreferenceChangeListener {
+    private lateinit var prefs: Preferences
+    private lateinit var prefSyncSchedule: SplitSwitchPreference
+    private lateinit var prefSyncScheduleIdle: SplitSwitchPreference
+    private lateinit var prefSyncScheduleBatteryOnly: SwitchPreferenceCompat
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.preferences_schedule, rootKey)
+
+        val context = requireContext()
+
+        prefs = Preferences(context)
+
+        prefSyncSchedule = findPreference(Preferences.PREF_SYNC_SCHEDULE)!!
+        prefSyncSchedule.onPreferenceClickListener = this
+
+        prefSyncScheduleIdle = findPreference(Preferences.PREF_SYNC_SCHEDULE_IDLE)!!
+        prefSyncScheduleIdle.onPreferenceClickListener = this
+
+        prefSyncScheduleBatteryOnly = findPreference(Preferences.PREF_SYNC_SCHEDULE_BATTERY_ONLY)!!
+
+        refreshSchedule()
+
+        for (key in arrayOf(
+            SyncScheduleDialogFragment.TAG,
+            SyncScheduleIdleDialogFragment.TAG,
+        )) {
+            parentFragmentManager.setFragmentResultListener(key, this, this)
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        prefs.registerListener(this)
+    }
+
+    override fun onPause() {
+        super.onPause()
+
+        prefs.unregisterListener(this)
+    }
+
+    private fun formatDurationMs(duration: Int): String =
+        if (duration % (60 * 60 * 1000) == 0) {
+            val hours = duration / 60 / 60 / 1000
+            resources.getQuantityString(R.plurals.duration_hours, hours, hours)
+        } else if (duration % (60 * 1000) == 0) {
+            val minutes = duration / 60 / 1000
+            resources.getQuantityString(R.plurals.duration_minutes, minutes, minutes)
+        } else {
+            val seconds = duration / 1000
+            resources.getQuantityString(R.plurals.duration_seconds, seconds, seconds)
+        }
+
+    private fun refreshSchedule() {
+        val context = requireContext()
+
+        val intent = context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+        val hasBattery = intent?.getBooleanExtra(BatteryManager.EXTRA_PRESENT, false) == true
+
+        val cycleDuration = formatDurationMs(prefs.scheduleCycleMs)
+        val syncDuration = formatDurationMs(prefs.scheduleSyncMs)
+        val idleDuration = formatDurationMs(prefs.scheduleIdleMs)
+
+        prefSyncSchedule.summary =
+            getString(R.string.pref_sync_schedule_desc, cycleDuration, syncDuration)
+
+        prefSyncScheduleIdle.summary =
+            getString(R.string.pref_sync_schedule_idle_desc, idleDuration)
+        prefSyncScheduleIdle.isEnabled = prefSyncSchedule.isChecked
+
+        prefSyncScheduleBatteryOnly.isVisible = hasBattery
+        prefSyncScheduleBatteryOnly.isEnabled = prefSyncSchedule.isChecked
+    }
+
+    override fun onFragmentResult(requestKey: String, bundle: Bundle) {
+        when (requestKey) {
+            SyncScheduleDialogFragment.TAG -> {
+                if (bundle.getBoolean(SyncScheduleDialogFragment.RESULT_SUCCESS)) {
+                    refreshSchedule()
+                }
+            }
+            SyncScheduleIdleDialogFragment.TAG -> {
+                if (bundle.getBoolean(SyncScheduleIdleDialogFragment.RESULT_SUCCESS)) {
+                    refreshSchedule()
+                }
+            }
+        }
+    }
+
+    override fun onPreferenceClick(preference: Preference): Boolean {
+        when (preference) {
+            prefSyncSchedule -> {
+                SyncScheduleDialogFragment().show(
+                    parentFragmentManager.beginTransaction(),
+                    SyncScheduleDialogFragment.TAG,
+                )
+                return true
+            }
+            prefSyncScheduleIdle -> {
+                SyncScheduleIdleDialogFragment().show(
+                    parentFragmentManager.beginTransaction(),
+                    SyncScheduleIdleDialogFragment.TAG,
+                )
+                return true
+            }
+        }
+
+        return false
+    }
+
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
+        when (key) {
+            Preferences.PREF_SYNC_SCHEDULE, Preferences.PREF_SYNC_SCHEDULE_IDLE -> refreshSchedule()
+        }
+    }
+}

--- a/app/src/main/java/com/chiller3/basicsync/syncthing/DeviceState.kt
+++ b/app/src/main/java/com/chiller3/basicsync/syncthing/DeviceState.kt
@@ -94,6 +94,10 @@ data class DeviceState(
     val isBatterySaver: Boolean = false,
     val isAutoSyncData: Boolean = false,
     val isInTimeWindow: Boolean = false,
+    val isIdleExpired: Boolean = false,
+    val busyFolders: Int = 0,
+    val connectedDevices: Int = 0,
+    val connectedOnce: Boolean = false,
     val proxyInfo: ProxyInfo = ProxyInfo("", ""),
 ) {
     companion object {
@@ -189,11 +193,11 @@ data class DeviceState(
             reasons.add(BlockedReason.AUTO_SYNC_DATA)
         }
 
-        if (!isInTimeWindow) {
+        if (!isInTimeWindow || isIdleExpired) {
             if (prefs.syncScheduleBatteryOnly && isPluggedIn) {
                 Log.d(TAG, "Ignoring sync schedule because device is plugged in")
             } else {
-                Log.d(TAG, "Blocked due to execution time window")
+                Log.d(TAG, "Blocked due to execution time window (idleExpired=${isIdleExpired})")
                 reasons.add(BlockedReason.TIME_SCHEDULE)
             }
         }
@@ -219,8 +223,24 @@ class DeviceStateTracker(private val context: Context) :
 
         const val MINIMUM_CYCLE_MS = 2 * MIN_FUTURITY
         const val MINIMUM_SYNC_MS = MIN_FUTURITY
+        const val MINIMUM_IDLE_MS = MIN_FUTURITY
 
         private var alarmId = 0
+
+        private fun newAlarmAction() =
+            "${DeviceStateTracker::class.java.canonicalName}.ALARM.$alarmId".apply {
+                alarmId += 1
+            }
+
+        private fun alarmPendingIntent(context: Context, action: String) =
+            PendingIntent.getBroadcast(
+                context,
+                0,
+                Intent(action).apply {
+                    setPackage(context.packageName)
+                },
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
 
         private fun getProxyInfo(): ProxyInfo {
             val proxyHost = System.getProperty("http.proxyHost")
@@ -411,66 +431,132 @@ class DeviceStateTracker(private val context: Context) :
 
     private var autoSyncHandle: Any? = null
 
-    private val timeScheduleAction = "${javaClass.canonicalName}.ALARM.$alarmId".apply {
-        alarmId += 1
-    }
-    private val timeSchedulePendingIntent = PendingIntent.getBroadcast(
-        context,
-        0,
-        Intent(timeScheduleAction).apply {
-            setPackage(context.packageName)
-        },
-        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
-    )
+    private val scheduleCycleAction = newAlarmAction()
+    private val scheduleIdleAction = newAlarmAction()
+    private val scheduleCyclePendingIntent = alarmPendingIntent(context, scheduleCycleAction)
+    private val scheduleIdlePendingIntent = alarmPendingIntent(context, scheduleIdleAction)
 
     // The OnAlarmListener variant of setExactAndAllowWhileIdle() isn't available until API 37.
-    private val timeScheduleReceiver: BroadcastReceiver = object : BroadcastReceiver() {
+    private val scheduleReceiver: BroadcastReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
-            alarmManager.cancel(timeSchedulePendingIntent)
+            when (intent.action) {
+                scheduleCycleAction -> {
+                    alarmManager.cancel(scheduleCyclePendingIntent)
+                    alarmManager.cancel(scheduleIdlePendingIntent)
 
-            val canRun = if (prefs.syncSchedule) {
-                val cycleDurationMs = max(prefs.scheduleCycleMs, MINIMUM_CYCLE_MS)
-                val syncDurationMs = max(prefs.scheduleSyncMs, MINIMUM_SYNC_MS)
-                val now = SystemClock.elapsedRealtime()
-                val inWindow = !state.isInTimeWindow
+                    val canRun = if (prefs.syncSchedule) {
+                        val cycleDurationMs = max(prefs.scheduleCycleMs, MINIMUM_CYCLE_MS)
+                        val syncDurationMs = max(prefs.scheduleSyncMs, MINIMUM_SYNC_MS)
+                        val inWindow = !state.isInTimeWindow
 
-                val wake = if (inWindow) {
-                    now + syncDurationMs
-                } else {
-                    now + (cycleDurationMs - syncDurationMs)
-                }
+                        val (label, durationMs) = if (inWindow) {
+                            "sync" to syncDurationMs
+                        } else {
+                            "off" to (cycleDurationMs - syncDurationMs)
+                        }
 
-                val exact = AlarmManagerCompat.canScheduleExactAlarms(alarmManager)
-                if (exact) {
-                    alarmManager.setExactAndAllowWhileIdle(
-                        AlarmManager.ELAPSED_REALTIME_WAKEUP,
-                        wake,
-                        timeSchedulePendingIntent,
+                        scheduleAlarm(label, scheduleCyclePendingIntent, durationMs.toLong())
+
+                        inWindow
+                    } else {
+                        Log.d(TAG, "Sync schedule is disabled")
+                        true
+                    }
+
+                    if (canRun) {
+                        scheduleIdleTimer()
+                    }
+
+                    state = state.copy(
+                        isInTimeWindow = canRun,
+                        isIdleExpired = false,
+                        connectedOnce = false,
                     )
-                } else {
-                    alarmManager.setAndAllowWhileIdle(
-                        AlarmManager.ELAPSED_REALTIME_WAKEUP,
-                        wake,
-                        timeSchedulePendingIntent,
-                    )
                 }
+                scheduleIdleAction -> {
+                    Log.d(TAG, "Idle window expired")
 
-                Log.d(TAG, "Time window updated: now=$now, inWindow=$inWindow, wake=$wake, exact=$exact")
-                inWindow
-            } else {
-                Log.d(TAG, "Time schedule is disabled")
-                true
+                    state = state.copy(isIdleExpired = true)
+                }
             }
-
-            state = state.copy(isInTimeWindow = canRun)
         }
     }
 
-    private val timeScheduleReset = Runnable {
-        Log.d(TAG, "Resetting time schedule listener")
+    private fun scheduleAlarm(type: String, pendingIntent: PendingIntent, sleepMs: Long) {
+        val now = SystemClock.elapsedRealtime()
+        val wake = now + sleepMs
 
-        state = state.copy(isInTimeWindow = false)
-        timeScheduleReceiver.onReceive(context, Intent())
+        val exact = AlarmManagerCompat.canScheduleExactAlarms(alarmManager)
+        if (exact) {
+            alarmManager.setExactAndAllowWhileIdle(
+                AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                wake,
+                pendingIntent,
+            )
+        } else {
+            alarmManager.setAndAllowWhileIdle(
+                AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                wake,
+                pendingIntent,
+            )
+        }
+
+        Log.d(TAG, "Scheduled alarm: type=$type, now=$now, wake=$wake, exact=$exact")
+    }
+
+    private fun scheduleIdleTimer() {
+        val enabled = prefs.syncSchedule && prefs.syncScheduleIdle
+        val isIdle = state.busyFolders == 0
+        val connectedOnce = state.connectedOnce
+
+        if (enabled && isIdle && connectedOnce) {
+            val syncIdleMs = max(prefs.scheduleIdleMs, MINIMUM_IDLE_MS)
+
+            scheduleAlarm("idle", scheduleIdlePendingIntent, syncIdleMs.toLong())
+        } else {
+            Log.d(TAG, "Not scheduling idle timer: enabled=$enabled, idle=$isIdle, connectedOnce=$connectedOnce")
+        }
+    }
+
+    fun updateBusyFolders(count: Int) {
+        handler.post {
+            if (state.busyFolders != count) {
+                alarmManager.cancel(scheduleIdlePendingIntent)
+
+                Log.d(TAG, "Busy folders updated: count=$count")
+
+                state = state.copy(busyFolders = count)
+                scheduleIdleTimer()
+            }
+        }
+    }
+
+    fun updateConnectedDevices(count: Int) {
+        handler.post {
+            if (state.connectedDevices != count) {
+                val connectedBefore = state.connectedOnce
+
+                Log.d(TAG, "Connected devices updated: count=$count, connectedBefore=$connectedBefore")
+
+                state = state.copy(
+                    connectedDevices = count,
+                    connectedOnce = connectedBefore || count > 0,
+                )
+
+                // After a single device connects, the idle timer is based solely on whether all
+                // folders are idle. Devices disconnecting do not affect the timer.
+                if (!connectedBefore && count > 0) {
+                    scheduleIdleTimer()
+                }
+            }
+        }
+    }
+
+    private val scheduleReset = Runnable {
+        Log.d(TAG, "Resetting sync schedule listener")
+
+        state = state.copy(isInTimeWindow = false, isIdleExpired = false)
+        scheduleReceiver.onReceive(context, Intent(scheduleCycleAction))
     }
 
     private val proxyChangeReceiver = object : BroadcastReceiver() {
@@ -504,13 +590,15 @@ class DeviceStateTracker(private val context: Context) :
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
         when (key) {
             Preferences.PREF_SYNC_SCHEDULE,
+            Preferences.PREF_SYNC_SCHEDULE_IDLE,
             Preferences.PREF_SCHEDULE_CYCLE_MS,
-            Preferences.PREF_SCHEDULE_SYNC_MS -> {
+            Preferences.PREF_SCHEDULE_SYNC_MS,
+            Preferences.PREF_SCHEDULE_IDLE_MS -> {
                 Log.d(TAG, "Preference $key changed")
 
                 // Try to debounce since these are generally changed at the same time.
-                handler.removeCallbacks(timeScheduleReset)
-                handler.post(timeScheduleReset)
+                handler.removeCallbacks(scheduleReset)
+                handler.post(scheduleReset)
             }
             // PREF_ALLOWED_WIFI_NETWORKS is checked in SyncthingService because we need the service
             // to request the location foreground permission first.
@@ -539,11 +627,14 @@ class DeviceStateTracker(private val context: Context) :
         autoSyncObserver.onStatusChanged(ContentResolver.SYNC_OBSERVER_TYPE_SETTINGS)
         ContextCompat.registerReceiver(
             context,
-            timeScheduleReceiver,
-            IntentFilter(timeScheduleAction),
+            scheduleReceiver,
+            IntentFilter().apply {
+                addAction(scheduleCycleAction)
+                addAction(scheduleIdleAction)
+            },
             ContextCompat.RECEIVER_NOT_EXPORTED,
         )
-        timeScheduleReceiver.onReceive(context, Intent())
+        scheduleReceiver.onReceive(context, Intent(scheduleCycleAction))
         context.registerReceiver(
             proxyChangeReceiver,
             IntentFilter(Proxy.PROXY_CHANGE_ACTION),
@@ -564,9 +655,10 @@ class DeviceStateTracker(private val context: Context) :
         context.unregisterReceiver(batteryStatusReceiver)
         context.unregisterReceiver(batterySaverReceiver)
         ContentResolver.removeStatusChangeListener(autoSyncHandle)
-        context.unregisterReceiver(timeScheduleReceiver)
-        alarmManager.cancel(timeSchedulePendingIntent)
-        handler.removeCallbacks(timeScheduleReset)
+        context.unregisterReceiver(scheduleReceiver)
+        alarmManager.cancel(scheduleCyclePendingIntent)
+        alarmManager.cancel(scheduleIdlePendingIntent)
+        handler.removeCallbacks(scheduleReset)
         context.unregisterReceiver(proxyChangeReceiver)
 
         this.listener = null

--- a/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
+++ b/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
@@ -551,6 +551,9 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
         Log.i(TAG, "Syncthing successfully stopped")
 
         synchronized(stateLock) {
+            deviceStateTracker.updateBusyFolders(0)
+            deviceStateTracker.updateConnectedDevices(0)
+
             syncthingConflicts = emptyList()
             syncthingApp = null
 
@@ -572,6 +575,16 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
         synchronized(stateLock) {
             syncthingConflicts = paths
         }
+    }
+
+    @WorkerThread
+    override fun onBusyFoldersUpdated(count: Int) {
+        deviceStateTracker.updateBusyFolders(count)
+    }
+
+    @WorkerThread
+    override fun onConnectedDevicesUpdated(count: Int) {
+        deviceStateTracker.updateConnectedDevices(count)
     }
 
     data class GuiInfo(

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -85,7 +85,7 @@
     <string name="dialog_min_battery_level_message">Въведете минималното ниво на батерията, необходимо за работата на Syncthing.</string>
     <string name="dialog_min_battery_level_hint">Процент</string>
     <string name="dialog_sync_schedule_title">Разписание за синхронизация</string>
-    <string name="dialog_sync_schedule_message">Въведете продължителността на цикъла и синхронизацията. Приемат се наставките <tt>h</tt> (часове), <tt>m</tt> (минути) и <tt>s</tt> (секунди).</string>
+    <string name="dialog_sync_schedule_message">Приемат се наставките <tt>h</tt> (часове), <tt>m</tt> (минути) и <tt>s</tt> (секунди).</string>
     <string name="dialog_sync_schedule_hint_cycle">Продължителност на цикъла</string>
     <string name="dialog_sync_schedule_hint_sync">Продължителност на синхронизацията</string>
     <string name="dialog_wifi_network_title">Wi-Fi мрежа</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -75,7 +75,7 @@
     <string name="dialog_min_battery_level_title">Mindestakkustand</string>
     <string name="dialog_min_battery_level_message">Den für die Ausführung von Syncthing erforderlichen Mindestakkustand eingeben.</string>
     <string name="dialog_min_battery_level_hint">Prozentzahl</string>
-    <string name="dialog_sync_schedule_message">Zyklus und Synchronisierungsdauer eingeben. Die Suffixe <tt>h</tt> (Stunden), <tt>m</tt> (Minuten) und <tt>s</tt> (Sekunden) werden akzeptiert.</string>
+    <string name="dialog_sync_schedule_message">Die Suffixe <tt>h</tt> (Stunden), <tt>m</tt> (Minuten) und <tt>s</tt> (Sekunden) werden akzeptiert.</string>
     <string name="dialog_sync_schedule_hint_cycle">Zyklusdauer</string>
     <string name="dialog_sync_schedule_hint_sync">Synchronisationsdauer</string>
     <string name="dialog_wifi_network_title">WLAN</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -78,7 +78,7 @@
     <string name="dialog_min_battery_level_message">Introduzca el nivel mínimo de batería neccesario para que Syncthing se ejecuta.</string>
     <string name="dialog_min_battery_level_hint">Porcentaje</string>
     <string name="dialog_sync_schedule_title">Horario de sincronización</string>
-    <string name="dialog_sync_schedule_message">Introduzca el ciclo y la duración de sincronización. Se aceptan los sufijos <tt>h</tt> (horas), <tt>m</tt> (minutos) y <tt>s</tt> (segundos).</string>
+    <string name="dialog_sync_schedule_message">Se aceptan los sufijos <tt>h</tt> (horas), <tt>m</tt> (minutos) y <tt>s</tt> (segundos).</string>
     <string name="dialog_sync_schedule_hint_cycle">Duración del ciclo</string>
     <string name="dialog_sync_schedule_hint_sync">Duración de sincronización</string>
     <string name="dialog_wifi_network_title">Red Wi-Fi</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -85,7 +85,7 @@
     <string name="dialog_min_battery_level_message">Entrez le niveau de batterie minimum requis pour que Syncthing fonctionne.</string>
     <string name="dialog_min_battery_level_hint">Pourcentage</string>
     <string name="dialog_sync_schedule_title">Planification de synchronisation</string>
-    <string name="dialog_sync_schedule_message">Entrez la durée des tranches et la durée de synchronisation. Les suffixes <tt>h</tt> (heures), <tt>m</tt> (minutes) et <tt>s</tt> (secondes) sont acceptés.</string>
+    <string name="dialog_sync_schedule_message">Les suffixes <tt>h</tt> (heures), <tt>m</tt> (minutes) et <tt>s</tt> (secondes) sont acceptés.</string>
     <string name="dialog_sync_schedule_hint_cycle">Durée de tranche</string>
     <string name="dialog_sync_schedule_hint_sync">Durée de synchronisation</string>
     <string name="dialog_wifi_network_title">Réseau Wi-Fi</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -85,7 +85,7 @@
     <string name="dialog_min_battery_level_message">Adja meg a Syncthing futtatásához szükséges minimális akkumulátor szintet.</string>
     <string name="dialog_min_battery_level_hint">Százalék</string>
     <string name="dialog_sync_schedule_title">Szinkronizálás időzítése</string>
-    <string name="dialog_sync_schedule_message">Adja meg a ciklust és a szinkronizálás időtartamát. Az <tt>h</tt> (óra), <tt>m</tt> (perc) és <tt>s</tt> (másodperc) utótagok elfogadottak.</string>
+    <string name="dialog_sync_schedule_message">Az <tt>h</tt> (óra), <tt>m</tt> (perc) és <tt>s</tt> (másodperc) utótagok elfogadottak.</string>
     <string name="dialog_sync_schedule_hint_cycle">Ciklus időtartama</string>
     <string name="dialog_sync_schedule_hint_sync">Szinkronizálás időtartama</string>
     <string name="dialog_wifi_network_title">Wi-Fi hálózat</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -79,7 +79,7 @@
     <string name="dialog_min_battery_level_message">Masukkan tingkat baterai minimum yang diperlukan agar Syncthing dapat berjalan.</string>
     <string name="dialog_min_battery_level_hint">Persentase</string>
     <string name="dialog_sync_schedule_title">Jadwal sinkronisasi</string>
-    <string name="dialog_sync_schedule_message">Masukkan siklus dan durasi sinkronisasi. Akhiran <tt>h</tt> (jam), <tt>m</tt> (menit), dan <tt>s</tt> (detik) diterima.</string>
+    <string name="dialog_sync_schedule_message">Akhiran <tt>h</tt> (jam), <tt>m</tt> (menit), dan <tt>s</tt> (detik) diterima.</string>
     <string name="dialog_sync_schedule_hint_cycle">Durasi siklus</string>
     <string name="dialog_sync_schedule_hint_sync">Durasi sinkronisasi</string>
     <string name="dialog_wifi_network_title">Jaringan Wi‑Fi</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -79,7 +79,7 @@
     <string name="dialog_min_battery_level_message">יש להזין את רמת הסוללה המזערית הנדרשת להרצת Syncthing.</string>
     <string name="dialog_min_battery_level_hint">אחוז</string>
     <string name="dialog_sync_schedule_title">לוח זמנים לסנכרון</string>
-    <string name="dialog_sync_schedule_message">יש להזין את משך המחזור והסנכרון. הסיומות <tt>h</tt> (שעות), <tt>m</tt> (דקות), ו־<tt>s</tt> (שניות) מקובלות.</string>
+    <string name="dialog_sync_schedule_message">הסיומות <tt>h</tt> (שעות), <tt>m</tt> (דקות), ו־<tt>s</tt> (שניות) מקובלות.</string>
     <string name="dialog_sync_schedule_hint_cycle">משך מחזור</string>
     <string name="dialog_sync_schedule_hint_sync">משך סנכרון</string>
     <string name="dialog_wifi_network_title">רשת Wi-Fi</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -76,7 +76,7 @@
     <string name="dialog_min_battery_level_message">Wpisz minimalny poziom naładowania baterii potrzebny do działania Syncthing.</string>
     <string name="dialog_min_battery_level_hint">Procent</string>
     <string name="dialog_sync_schedule_title">Harmonogram synchronizacji</string>
-    <string name="dialog_sync_schedule_message">Wpisz cykl i czas trwania synchronizacji. Akceptowane są sufiksy <tt>h</tt> (godziny),<tt>m</tt> (minuty) i <tt>s</tt> (sekundy).</string>
+    <string name="dialog_sync_schedule_message">Akceptowane są sufiksy <tt>h</tt> (godziny),<tt>m</tt> (minuty) i <tt>s</tt> (sekundy).</string>
     <string name="dialog_sync_schedule_hint_cycle">Czas trwania cyklu</string>
     <string name="dialog_sync_schedule_hint_sync">Czas trwania synchronizacji</string>
     <string name="dialog_wifi_network_title">Sieć Wi-Fi</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -85,7 +85,7 @@
     <string name="dialog_min_battery_level_message">Introdu nivelul minim al bateriei necesar pentru ca Syncthing să ruleze.</string>
     <string name="dialog_min_battery_level_hint">Procentaj</string>
     <string name="dialog_sync_schedule_title">Sincronizare programată</string>
-    <string name="dialog_sync_schedule_message">Introdu ciclul și durata de sincronizare. Sunt acceptate sufixele <tt>h</tt> (ore), <tt>m</tt> (minute) și <tt>s</tt> (secunde).</string>
+    <string name="dialog_sync_schedule_message">Sunt acceptate sufixele <tt>h</tt> (ore), <tt>m</tt> (minute) și <tt>s</tt> (secunde).</string>
     <string name="dialog_sync_schedule_hint_cycle">Durata ciclului</string>
     <string name="dialog_sync_schedule_hint_sync">Durata sincronizării</string>
     <string name="dialog_wifi_network_title">Rețea Wi-Fi</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -79,7 +79,7 @@
     <string name="dialog_min_battery_level_message">Syncthing\'in çalışması için gereken en düşük pil seviyesini girin.</string>
     <string name="dialog_min_battery_level_hint">Yüzde</string>
     <string name="dialog_sync_schedule_title">Eşitleme zamanlaması</string>
-    <string name="dialog_sync_schedule_message">Döngü ve eşitleme süresini girin. <tt>h</tt> (saat), <tt>m</tt> (dakika) ve <tt>s</tt> (saniye) son ekleri kabul edilir.</string>
+    <string name="dialog_sync_schedule_message"><tt>h</tt> (saat), <tt>m</tt> (dakika) ve <tt>s</tt> (saniye) son ekleri kabul edilir.</string>
     <string name="dialog_sync_schedule_hint_cycle">Döngü süresi</string>
     <string name="dialog_sync_schedule_hint_sync">Eşitleme süresi</string>
     <string name="dialog_wifi_network_title">Kablosuz ağ</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -79,7 +79,7 @@
     <string name="dialog_min_battery_level_title">最低电池电量</string>
     <string name="dialog_min_battery_level_message">请输入 Syncthing 运行所需的最低电池电量。</string>
     <string name="dialog_min_battery_level_hint">百分比</string>
-    <string name="dialog_sync_schedule_message">请输入周期和同步时长。支持使用 <tt>h</tt>（小时）、<tt>m</tt>（分钟）和 <tt>s</tt>（秒）后缀。</string>
+    <string name="dialog_sync_schedule_message">支持使用 <tt>h</tt>（小时）、<tt>m</tt>（分钟）和 <tt>s</tt>（秒）后缀。</string>
     <string name="dialog_sync_schedule_title">同步时间表</string>
     <string name="dialog_sync_schedule_hint_cycle">周期时长</string>
     <string name="dialog_sync_schedule_hint_sync">同步时长</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -85,7 +85,7 @@
     <string name="dialog_min_battery_level_message">輸入允許 Syncthing 執行的最低電池電量。</string>
     <string name="dialog_min_battery_level_hint">百分比</string>
     <string name="dialog_sync_schedule_title">同步排程</string>
-    <string name="dialog_sync_schedule_message">輸入週期與同步時長。可接受 <tt>h</tt>（小時）、<tt>m</tt>（分鐘）及 <tt>s</tt>（秒）作為後綴。</string>
+    <string name="dialog_sync_schedule_message">可接受 <tt>h</tt>（小時）、<tt>m</tt>（分鐘）及 <tt>s</tt>（秒）作為後綴。</string>
     <string name="dialog_sync_schedule_hint_cycle">週期時長</string>
     <string name="dialog_sync_schedule_hint_sync">同步時長</string>
     <string name="dialog_wifi_network_title">Wi-Fi 網路</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,14 +74,10 @@
     <string name="pref_respect_auto_sync_data_name">Respect auto-sync data setting</string>
     <!-- Description for the preference that controls whether to respect the auto-sync data option from Android's settings. -->
     <string name="pref_respect_auto_sync_data_desc">Only run when Android\'s auto-sync data setting is enabled.</string>
-    <!-- Title for the preference that enables syncing on a time schedule. Example of time schedule: run for 5 minutes every hour. -->
-    <string name="pref_sync_schedule_name">Sync on time schedule</string>
-    <!-- Description for the preference that enables syncing on a time schedule. %1$s is the time window duration. %2$s is how long to sync within the time window. Both timestamps are formatted using the duration_* strings before being inserted here. -->
-    <string name="pref_sync_schedule_desc">Sync for %2$s during every window of %1$s.</string>
-    <!-- Title for the preference that only enables the time schedule feature when on battery power. -->
-    <string name="pref_sync_schedule_battery_only_name">Use time schedule only on battery</string>
-    <!-- Description for the preference that only enables the time schedule feature when on battery power. -->
-    <string name="pref_sync_schedule_battery_only_desc">When plugged in, the time schedule will be ignored.</string>
+    <!-- Title for the preference that opens the sync schedule settings screen. -->
+    <string name="pref_sync_schedule_settings_name">Sync schedule</string>
+    <!-- Description for the preference that opens the sync schedule settings screen. -->
+    <string name="pref_sync_schedule_settings_desc">Run Syncthing periodically based on a fixed time interval.</string>
     <!-- Title for the preference that keeps Syncthing always running. When run conditions prevent it from syncing, Syncthing is paused instead of stopped. -->
     <string name="pref_keep_alive_name">Keep Syncthing alive</string>
     <!-- Description for the preference that keeps Syncthing always running. -->
@@ -135,6 +131,19 @@
     <!-- Preference for manually adding an allowed Wi-Fi network. This can be used, for example, to add hidden Wi-Fi networks or networks that are currently out of range. -->
     <string name="pref_add_wifi_network_name">Manually add Wi-Fi network</string>
 
+    <!-- Title for the preference that enables syncing on a time schedule. Example of time schedule: run for 5 minutes every hour. -->
+    <string name="pref_sync_schedule_name">Sync on time schedule</string>
+    <!-- Description for the preference that enables syncing on a time schedule. %1$s is the time window duration. %2$s is how long to sync within the time window. Both timestamps are formatted using the duration_* strings before being inserted here. -->
+    <string name="pref_sync_schedule_desc">Sync for %2$s during every window of %1$s.</string>
+    <!-- Title for the preference that enables stopping Syncthing early if it has been idle. -->
+    <string name="pref_sync_schedule_idle_name">Stop early when idle</string>
+    <!-- Description for the preference that enables stopping Syncthing early if it has been idle. %1$s is the idle duration. The timestamp is formatted using the duration_* strings before being inserted here. -->
+    <string name="pref_sync_schedule_idle_desc">Stop Syncthing before the sync window ends if at least one device connected and all folders have been idle for %1$s.</string>
+    <!-- Title for the preference that only enables the time schedule feature when on battery power. -->
+    <string name="pref_sync_schedule_battery_only_name">Use time schedule only on battery</string>
+    <!-- Description for the preference that only enables the time schedule feature when on battery power. -->
+    <string name="pref_sync_schedule_battery_only_desc">When plugged in, the time schedule will be ignored.</string>
+
     <!-- Button to open a dialog containing more details about an error that just occurred. -->
     <string name="action_details">Details</string>
     <!-- Title shown in a dialog containing more details about an error that just occurred. -->
@@ -186,11 +195,13 @@
     <!-- Title of the dialog for configuring the time schedule feature. -->
     <string name="dialog_sync_schedule_title">Sync schedule</string>
     <!-- Message shown in the dialog for configuring the time schedule feature. The 'h', 'm', and 's' suffixes are used for every language. -->
-    <string name="dialog_sync_schedule_message">Enter the cycle and sync duration. The <tt>h</tt> (hours), <tt>m</tt> (minutes), and <tt>s</tt> (seconds) suffixes are accepted.</string>
+    <string name="dialog_sync_schedule_message">The <tt>h</tt> (hours), <tt>m</tt> (minutes), and <tt>s</tt> (seconds) suffixes are accepted.</string>
     <!-- Textbox hint shown in the dialog for configuring the time schedule feature. This represents the length of the time window. For example the "every hour" part of "sync for 5 minutes every hour". -->
     <string name="dialog_sync_schedule_hint_cycle">Cycle duration</string>
     <!-- Textbox hint shown in the dialog for configuring the time schedule feature. This represents the sync duration within the time window. For example the "5 minutes" part of "sync for 5 minutes every hour". -->
     <string name="dialog_sync_schedule_hint_sync">Sync duration</string>
+    <!-- Textbox hint shown in the dialog for configuring the time schedule feature. This represents the idle duration. This is for stopping Syncthing early before the sync window ends if it's been idle for a period of time. -->
+    <string name="dialog_sync_schedule_hint_idle">Idle duration</string>
     <!-- Title of the dialog for manually adding an allowed Wi-Fi network. -->
     <string name="dialog_wifi_network_title">Wi-Fi network</string>
     <!-- Message shown in the dialog for manually adding an allowed Wi-Fi network. -->

--- a/app/src/main/res/xml/preferences_root.xml
+++ b/app/src/main/res/xml/preferences_root.xml
@@ -115,15 +115,11 @@
             app:summary="@string/pref_respect_auto_sync_data_desc"
             app:iconSpaceReserved="false" />
 
-        <com.chiller3.basicsync.view.SplitSwitchPreference
-            app:key="sync_schedule"
-            app:title="@string/pref_sync_schedule_name"
-            app:iconSpaceReserved="false" />
-
-        <SwitchPreferenceCompat
-            app:key="sync_schedule_battery_only"
-            app:title="@string/pref_sync_schedule_battery_only_name"
-            app:summary="@string/pref_sync_schedule_battery_only_desc"
+        <Preference
+            app:key="sync_schedule_settings"
+            app:persistent="false"
+            app:title="@string/pref_sync_schedule_settings_name"
+            app:summary="@string/pref_sync_schedule_settings_desc"
             app:iconSpaceReserved="false" />
 
         <SwitchPreferenceCompat

--- a/app/src/main/res/xml/preferences_schedule.xml
+++ b/app/src/main/res/xml/preferences_schedule.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    SPDX-FileCopyrightText: 2026 Andrew Gunnerson
+    SPDX-License-Identifier: GPL-3.0-only
+-->
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+    <PreferenceCategory
+        app:title="@string/pref_header_run_conditions"
+        app:iconSpaceReserved="false">
+
+        <com.chiller3.basicsync.view.SplitSwitchPreference
+            app:key="sync_schedule"
+            app:title="@string/pref_sync_schedule_name"
+            app:iconSpaceReserved="false" />
+
+        <com.chiller3.basicsync.view.SplitSwitchPreference
+            app:key="sync_schedule_idle"
+            app:title="@string/pref_sync_schedule_idle_name"
+            app:iconSpaceReserved="false" />
+
+        <SwitchPreferenceCompat
+            app:key="sync_schedule_battery_only"
+            app:title="@string/pref_sync_schedule_battery_only_name"
+            app:summary="@string/pref_sync_schedule_battery_only_desc"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/stbridge/stbridge.go
+++ b/stbridge/stbridge.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -38,6 +39,7 @@ import (
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/locations"
+	"github.com/syncthing/syncthing/lib/model"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/rand"
 	"github.com/syncthing/syncthing/lib/svcutil"
@@ -290,6 +292,10 @@ type SyncthingStatusReceiver interface {
 	// support passing a list of strings to the JVM. This works for arbitrary
 	// paths on Linux.
 	OnConflictsUpdated(paths0Sep string)
+
+	OnBusyFoldersUpdated(count int32)
+
+	OnConnectedDevicesUpdated(count int32)
 }
 
 // db.DB is internal, so it's unnameable and we can't create a function that
@@ -325,6 +331,38 @@ func dispatchConflicts(
 	receiver.OnConflictsUpdated(paths0Sep.String())
 }
 
+// The scanning states are intentionally excluded because we only want mutating
+// operations to interrupt the idle timer.
+var busyEvents = []string{
+	model.FolderSyncWaiting.String(),
+	model.FolderSyncPreparing.String(),
+	model.FolderSyncing.String(),
+	model.FolderCleaning.String(),
+	model.FolderCleanWaiting.String(),
+}
+
+func dispatchBusyFolders(
+	folderStates map[string]string,
+	receiver SyncthingStatusReceiver,
+) {
+	busyCount := int32(0)
+
+	for _, state := range folderStates {
+		if slices.Contains(busyEvents, state) {
+			busyCount += 1
+		}
+	}
+
+	receiver.OnBusyFoldersUpdated(busyCount)
+}
+
+func dispatchConnectedDevices(
+	devicesConnected map[string]struct{},
+	receiver SyncthingStatusReceiver,
+) {
+	receiver.OnConnectedDevicesUpdated(int32(len(devicesConnected)))
+}
+
 func eventLoop(
 	ctx context.Context,
 	stopped chan struct{},
@@ -338,9 +376,15 @@ func eventLoop(
 	sub := evLogger.Subscribe(
 		events.LocalChangeDetected |
 			events.RemoteChangeDetected |
+			events.StateChanged |
+			events.DeviceConnected |
+			events.DeviceDisconnected |
 			events.ConfigSaved,
 	)
 	defer sub.Unsubscribe()
+
+	devicesConnected := map[string]struct{}{}
+	folderStates := map[string]string{}
 
 	for {
 		select {
@@ -368,6 +412,31 @@ func eventLoop(
 
 				dispatchConflicts(folderConflicts, folderToPath, receiver)
 
+			case events.StateChanged:
+				data := evt.Data.(map[string]interface{})
+				folder := data["folder"].(string)
+				state := data["to"].(string)
+
+				folderStates[folder] = state
+
+				dispatchBusyFolders(folderStates, receiver)
+
+			case events.DeviceConnected:
+				data := evt.Data.(map[string]string)
+				deviceID := data["id"]
+
+				devicesConnected[deviceID] = struct{}{}
+
+				dispatchConnectedDevices(devicesConnected, receiver)
+
+			case events.DeviceDisconnected:
+				data := evt.Data.(map[string]string)
+				deviceID := data["id"]
+
+				delete(devicesConnected, deviceID)
+
+				dispatchConnectedDevices(devicesConnected, receiver)
+
 			// When a folder is deleted, we need to manually clear out the
 			// corresponding conflicts because we will not receive deletion
 			// events for them.
@@ -387,10 +456,21 @@ func eventLoop(
 					}
 				}
 
+				for key := range folderStates {
+					if _, ok := folderToPath[key]; !ok {
+						delete(folderStates, key)
+					}
+				}
+
 				dispatchConflicts(folderConflicts, folderToPath, receiver)
+				dispatchBusyFolders(folderStates, receiver)
+
+				// Unlike folders, we don't need to remove deleted devices from
+				// devicesConnected. We'll always receive a disconnection event
+				// when connections are closed during deletion.
 
 			default:
-				// Ignore.
+				log.Printf("Unexpected event: %+v", evt)
 			}
 
 		case <-ctx.Done():


### PR DESCRIPTION
When enabled, Syncthing will stop before the sync interval ends if at least one device successfully connected and all folders have been idle for a configurable period of time.

All of the sync schedule UI options have been moved to another screen since adding yet another option is starting to clutter the main screen.

Closes: #116