### PR TITLE
Catch ActivityNotFoundException when opening external WebView links

### DIFF
--- a/app/src/main/java/com/chiller3/basicsync/settings/WebUiActivity.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/WebUiActivity.kt
@@ -6,6 +6,7 @@
 package com.chiller3.basicsync.settings
 
 import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.res.Configuration
 import android.net.Uri
@@ -110,7 +111,11 @@ class WebUiActivity : AppCompatActivity() {
             if (uri.scheme == guiUri.scheme && uri.host == guiUri.host && uri.port == guiUri.port) {
                 return false
             } else {
-                startActivity(Intent(Intent.ACTION_VIEW, uri))
+                try {
+                    startActivity(Intent(Intent.ACTION_VIEW, uri))
+                } catch (e: ActivityNotFoundException) {
+                    Log.w(TAG, "No app installed to handle $uri", e)
+                }
                 return true
             }
         }


### PR DESCRIPTION
Closes #131.

### What changes

`WebUiActivity.kt`'s `shouldOverrideUrlLoading` calls `startActivity(Intent(Intent.ACTION_VIEW, uri))` to hand off external links (Syncthing docs, forum, etc.) to a system browser. If no installed app can handle that intent, `startActivity` raises `ActivityNotFoundException` and the activity crashes.

This wraps the call in a `try / catch (ActivityNotFoundException)` and logs a warning. The click becomes a silent no-op instead of a crash, which is the standard outcome when there is no browser registered.

```diff
 override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
     val uri = request.url
     val guiUri = guiUri

     if (uri.scheme == guiUri.scheme && uri.host == guiUri.host && uri.port == guiUri.port) {
         return false
     } else {
-        startActivity(Intent(Intent.ACTION_VIEW, uri))
+        try {
+            startActivity(Intent(Intent.ACTION_VIEW, uri))
+        } catch (e: ActivityNotFoundException) {
+            Log.w(TAG, "No app installed to handle $uri", e)
+        }
         return true
     }
 }
```

`android.content.ActivityNotFoundException` is added to the imports. Nothing else moves.
