### PR TITLE
SyncthingService: Don't wait for runner thread to exit

### DIFF
--- a/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
+++ b/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
@@ -279,13 +279,14 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
     override fun onDestroy() {
         super.onDestroy()
 
+        // We intentionally don't wait for runnerThread to exit. Syncthing can sometimes take a few
+        // seconds to fully exit, which can trigger an ANR warning. This is not a problem because if
+        // a new service starts while Syncthing from this service is still shutting down, the global
+        // lock in stbridge will just block the startup.
         synchronized(stateLock) {
             shouldThreadRun = false
         }
         stateChanged()
-
-        // This should be quick.
-        runnerThread.join()
 
         synchronized(stateLock) {
             listeners.clear()


### PR DESCRIPTION
Syncthing sometimes takes upwards of 10 seconds to exit, which can cause Android to show an ANR warning. We don't actually need to wait because even if the shutdown takes a while and the user tries to start up the service again in the meantime, stbridge's global lock will prevent any race conditions. The startup just won't begin until the previous shutdown completes.