### PR TITLE
WebUiScreen: Render content edge to edge

### DIFF
--- a/app/src/main/java/com/chiller3/basicsync/settings/WebUiActivity.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/WebUiActivity.kt
@@ -16,10 +16,7 @@ class WebUiActivity : BaseActivity() {
 
         setContent {
             AppTheme {
-                WebUiScreen(
-                    onBack = ::finish,
-                    onExit = ::finishAffinity,
-                )
+                WebUiScreen(onExit = ::finishAffinity)
             }
         }
     }

--- a/app/src/main/java/com/chiller3/basicsync/settings/WebUiScreen.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/WebUiScreen.kt
@@ -26,20 +26,12 @@ import android.webkit.WebViewClient
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.ime
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.union
-import androidx.compose.material3.ScaffoldDefaults
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
@@ -74,10 +66,7 @@ private fun jsEscape(s: String) = buildString {
 }
 
 @Composable
-fun WebUiScreen(
-    onBack: () -> Unit,
-    onExit: () -> Unit,
-) {
+fun WebUiScreen(onExit: () -> Unit) {
     val context = LocalContext.current
     val resources = LocalResources.current
 
@@ -267,11 +256,7 @@ fun WebUiScreen(
         }
     }
 
-    AppScreen(
-        title = { Text(text = stringResource(R.string.app_name_upstream)) },
-        onBack = onBack,
-        contentWindowInsets = ScaffoldDefaults.contentWindowInsets.union(WindowInsets.ime),
-    ) { params ->
+    AppScreen(fullScreenContent = true) { params ->
         AndroidView(
             factory = {
                 webView.apply {
@@ -307,7 +292,6 @@ fun WebUiScreen(
             onRelease = {
                 it.destroy()
             },
-            modifier = Modifier.fillMaxSize().padding(params.contentPadding),
         )
 
         if (showBrowserAlert) {

--- a/app/src/main/java/com/chiller3/basicsync/ui/Screen.kt
+++ b/app/src/main/java/com/chiller3/basicsync/ui/Screen.kt
@@ -34,7 +34,7 @@ data class AppScreenParams(
 
 @Composable
 fun AppScreen(
-    title: @Composable () -> Unit,
+    title: (@Composable () -> Unit)? = null,
     onBack: (() -> Unit)? = null,
     contentWindowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
     fullScreenContent: Boolean = false,
@@ -47,30 +47,32 @@ fun AppScreen(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         topBar = {
-            TopAppBar(
-                title = title,
-                navigationIcon = {
-                    onBack?.let { onClick ->
-                        IconButton(onClick = onClick) {
-                            @SuppressLint("PrivateResource")
-                            Icon(
-                                imageVector = Icons.AutoMirrored.ArrowBack,
-                                contentDescription = stringResource(
-                                    androidx.appcompat.R.string.abc_action_bar_up_description,
-                                ),
-                            )
+            title?.let { title ->
+                TopAppBar(
+                    title = title,
+                    navigationIcon = {
+                        onBack?.let { onClick ->
+                            IconButton(onClick = onClick) {
+                                @SuppressLint("PrivateResource")
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.ArrowBack,
+                                    contentDescription = stringResource(
+                                        androidx.appcompat.R.string.abc_action_bar_up_description,
+                                    ),
+                                )
+                            }
                         }
-                    }
-                },
-                colors = PreferenceDefaults.appBarColors().let {
-                    if (fullScreenContent) {
-                        it.copy(containerColor = it.containerColor.copy(alpha = 0.5f))
-                    } else {
-                        it
-                    }
-                },
-                scrollBehavior = scrollBehavior,
-            )
+                    },
+                    colors = PreferenceDefaults.appBarColors().let {
+                        if (fullScreenContent) {
+                            it.copy(containerColor = it.containerColor.copy(alpha = 0.5f))
+                        } else {
+                            it
+                        }
+                    },
+                    scrollBehavior = scrollBehavior,
+                )
+            }
         },
         containerColor = PreferenceDefaults.containerColor,
         contentWindowInsets = contentWindowInsets,

--- a/app/src/main/res/raw/webview_bridge.js
+++ b/app/src/main/res/raw/webview_bridge.js
@@ -229,4 +229,58 @@ function bridgeInit(isTv) {
         style.innerHTML = ':focus { border: 3px dotted !important; }';
         document.body.appendChild(style);
     }
+
+    // We use the bootstrap nav bar as the app nav bar, so don't let it get scrolled away.
+    const nav = document.getElementsByTagName('nav')[0];
+    nav.classList.remove('navbar-top');
+    nav.classList.add('navbar-fixed-top');
+
+    // The webview is edge-to-edge, so insets need to be handled manually.
+    const origContent = document.getElementsByClassName('content')[0];
+    const safeContent = document.createElement('div');
+    safeContent.classList.add('safe-content');
+    origContent.parentElement.insertBefore(safeContent, origContent);
+    safeContent.appendChild(origContent);
+
+    const edgeToEdgeStyle = document.createElement('style');
+    edgeToEdgeStyle.innerHTML = `
+        /*
+         * Normally, Syncthing only makes the dropdown menus scrollable on narrow screens. However,
+         * due to us using a fixed/sticky nav bar, on wide screens, it's no longer possible to
+         * scroll the menus by scrolling the page itself. We have to make the menus individually
+         * scrollable instead.
+         */
+        .dropdown-menu {
+            column-count: auto !important;
+            height: unset !important;
+            /* Roughly the amount of free space excluding insets and nav bar. */
+            max-height: max(50px, calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom) - 60px));
+            overflow-y: scroll;
+            /* Avoid scrolling the content underneath after reaching the boundary. */
+            overscroll-behavior-y: contain;
+        }
+
+        .navbar-fixed-top {
+            /* The vendored bootstrap version is too old to have the sticky-top class. */
+            position: sticky;
+
+            padding-top: env(safe-area-inset-top);
+            padding-right: env(safe-area-inset-right);
+            padding-left: env(safe-area-inset-left);
+        }
+
+        .safe-content {
+            padding-right: env(safe-area-inset-right);
+            padding-bottom: env(safe-area-inset-bottom);
+            padding-left: env(safe-area-inset-left);
+        }
+
+        .modal-content {
+            margin-top: env(safe-area-inset-top);
+            margin-right: env(safe-area-inset-right);
+            margin-bottom: env(safe-area-inset-bottom);
+            margin-left: env(safe-area-inset-left);
+        }
+    `;
+    document.body.appendChild(edgeToEdgeStyle);
 }

--- a/app/src/main/res/values/strings_notranslate.xml
+++ b/app/src/main/res/values/strings_notranslate.xml
@@ -6,6 +6,4 @@
 <resources>
     <string name="app_name_release" translatable="false">BasicSync</string>
     <string name="app_name_debug" translatable="false">BasicSync (Debug)</string>
-
-    <string name="app_name_upstream" translatable="false">Syncthing</string>
 </resources>


### PR DESCRIPTION
Syncthing's web UI already contains a navigation bar, so avoid duplicating it with a native one. Since `WebView` supports window insets, we can just hack in some CSS to make use of it and also to prevent the navigation bar from being scrolled away.

The only issue is that the overscroll effect when scrolling the main content or a modal dialog also affects the navigation bar. Setting `overscroll-behavior-y: none` does not seem to work properly in `WebView`s.