### PR TITLE
WebUiScreen: Close modals with back button

### DIFF
--- a/app/src/main/java/com/chiller3/basicsync/settings/WebUiScreen.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/WebUiScreen.kt
@@ -29,6 +29,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -84,12 +85,6 @@ fun WebUiScreen(onExit: () -> Unit) {
         }
     }
 
-    var canGoBack by remember { mutableStateOf(false) }
-    BackHandler(
-        enabled = canGoBack,
-        onBack = { webView.goBack() },
-    )
-
     var guiUri by remember { mutableStateOf<Uri?>(null) }
     var guiCert by remember { mutableStateOf<X509Certificate?>(null) }
     rememberServiceEventWatcher(
@@ -143,6 +138,23 @@ fun WebUiScreen(onExit: () -> Unit) {
         webView.evaluateJavascript("bridgeInit($isTv);") {}
     }
 
+    fun closeTopModal() {
+        webView.evaluateJavascript("closeTopModal();") {}
+    }
+
+    var modalsOpen by remember { mutableIntStateOf(0) }
+    var hasBrowserHistory by remember { mutableStateOf(false) }
+    BackHandler(
+        enabled = modalsOpen > 0 || hasBrowserHistory,
+        onBack = {
+            if (modalsOpen > 0) {
+                closeTopModal()
+            } else if (hasBrowserHistory) {
+                webView.goBack()
+            }
+        },
+    )
+
     val requestQrScanner = rememberLauncherForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) {
@@ -189,6 +201,11 @@ fun WebUiScreen(onExit: () -> Unit) {
             @JavascriptInterface
             fun scanQrCode() {
                 requestQrScanner.launch(Intent(context, QrScannerActivity::class.java))
+            }
+
+            @JavascriptInterface
+            fun onModalsOpenChanged(count: Int) {
+                modalsOpen = count
             }
         }
     }
@@ -251,7 +268,7 @@ fun WebUiScreen(onExit: () -> Unit) {
             }
 
             override fun doUpdateVisitedHistory(view: WebView, url: String, isReload: Boolean) {
-                canGoBack = view.canGoBack()
+                hasBrowserHistory = view.canGoBack()
             }
         }
     }

--- a/app/src/main/res/raw/webview_bridge.js
+++ b/app/src/main/res/raw/webview_bridge.js
@@ -24,7 +24,7 @@ function addFolderPicker(element) {
     const buttonGroup = document.createElement('span');
     buttonGroup.classList.add('input-group-btn');
 
-    angular.element(document).injector().invoke(function($compile) {
+    angular.element(document).injector().invoke(function ($compile) {
         const scope = angular.element(element).scope();
         $compile(button)(scope);
 
@@ -40,7 +40,7 @@ function addFolderPicker(element) {
     inputGroup.appendChild(element);
     inputGroup.appendChild(buttonGroup);
 
-    button.addEventListener('click', function() {
+    button.addEventListener('click', function () {
         BasicSync.openFolderPicker(element.value);
     }, false);
 
@@ -67,14 +67,14 @@ function addQrScanner(element) {
     button.setAttribute('tooltip', '');
     button.appendChild(icon);
 
-    angular.element(document).injector().invoke(function($compile) {
+    angular.element(document).injector().invoke(function ($compile) {
         const scope = angular.element(element).scope();
         $compile(button)(scope);
 
         element.appendChild(button);
     });
 
-    button.addEventListener('click', function() {
+    button.addEventListener('click', function () {
         BasicSync.scanQrCode();
     }, false);
 }
@@ -150,7 +150,7 @@ function tryMutate(isTv) {
     for (const className of actionsToHide) {
         const icon = document.getElementsByClassName(className)[0];
         if (icon) {
-            hideParent(icon, function(parent) {
+            hideParent(icon, function (parent) {
                 return parent instanceof HTMLLIElement;
             });
             actionsToHide.delete(className);
@@ -182,6 +182,27 @@ function onDeviceIdScanned(deviceId) {
     elemDeviceId.dispatchEvent(new InputEvent('input'));
 }
 
+function closeTopModal() {
+    const modals = document.getElementsByClassName('modal');
+    var topModal = null;
+    var topZIndex = null;
+
+    for (const elem of modals) {
+        const modal = $(elem).data('bs.modal');
+        if (modal && modal.isShown) {
+            const zIndex = parseInt(window.getComputedStyle(elem).getPropertyValue('z-index'));
+            if (topModal === null || zIndex >= topZIndex) {
+                topModal = modal;
+                topZIndex = zIndex;
+            }
+        }
+    }
+
+    if (topModal !== null) {
+        topModal.hide();
+    }
+}
+
 function bridgeInit(isTv) {
     if (!tryMutate(isTv)) {
         const callback = (mutationList, observer) => {
@@ -202,6 +223,18 @@ function bridgeInit(isTv) {
         });
     }
 
+    var modalsOpen = 0;
+
+    $(document).on('shown.bs.modal', function (e) {
+        modalsOpen++;
+        BasicSync.onModalsOpenChanged(modalsOpen);
+    });
+
+    $(document).on('hidden.bs.modal', function (e) {
+        modalsOpen--;
+        BasicSync.onModalsOpenChanged(modalsOpen);
+    });
+
     // Prevent arrow keys from opening dropdown menus. There is no good way to leave the menu
     // afterwards because the up/down arrow keys are hijacked to only move within the list and a TV
     // remote has no escape button to close the menu. Spatial navigation already works very well for
@@ -219,7 +252,7 @@ function bridgeInit(isTv) {
 
             e.target.readOnly = true;
             if (!wasReadOnly) {
-                setTimeout(function() { e.target.readOnly = false; }, 100);
+                setTimeout(function () { e.target.readOnly = false; }, 100);
             }
         }
     });


### PR DESCRIPTION
The behavior is now more in line with how native dialogs work when pressing the back button. Nested modals are supported and each back invocation will only close the topmost one. After all modals are closed, it falls back to the previous behavior of going to the previous `WebView` history page or finishing the `Activity` if there is no history left.