### PR TITLE
WebUiActivity: Handle uiMode configuration changes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -121,7 +121,7 @@
         <activity
             android:name=".settings.WebUiActivity"
             android:exported="false"
-            android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize" />
+            android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode" />
 
         <service
             android:name=".syncthing.SyncthingService"


### PR DESCRIPTION
`WebView` already handles this automatically. We can avoid recreating the `Activity` so that the state of modal dialogs isn't lost when switching between light and dark mode.