### PR TITLE
Write support bundles to external files directory

### DIFF
--- a/app/src/main/java/com/chiller3/basicsync/MainApplication.kt
+++ b/app/src/main/java/com/chiller3/basicsync/MainApplication.kt
@@ -36,6 +36,10 @@ class MainApplication : Application() {
 
         Preferences(this).migrate()
 
-        Stbridge.initDirs(filesDir.toString(), cacheDir.toString())
+        Stbridge.initDirs(
+            filesDir.toString(),
+            cacheDir.toString(),
+            getExternalFilesDir(null)!!.toString(),
+        )
     }
 }

--- a/app/src/main/java/com/chiller3/basicsync/settings/WebUiScreen.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/WebUiScreen.kt
@@ -14,6 +14,8 @@ import android.net.Uri
 import android.net.http.SslCertificate
 import android.net.http.SslError
 import android.os.Build
+import android.os.Environment
+import android.provider.DocumentsContract
 import android.util.Base64
 import android.util.Log
 import android.view.ViewGroup
@@ -40,6 +42,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.net.toUri
 import androidx.lifecycle.compose.LifecycleResumeEffect
 import com.chiller3.basicsync.R
+import com.chiller3.basicsync.extension.DOCUMENTSUI_AUTHORITY
 import com.chiller3.basicsync.syncthing.SyncthingService
 import com.chiller3.basicsync.ui.AppScreen
 import java.io.ByteArrayInputStream
@@ -210,7 +213,7 @@ fun WebUiScreen(onExit: () -> Unit) {
         }
     }
 
-    var showBrowserAlert by remember { mutableStateOf(false) }
+    var showAlert by remember { mutableIntStateOf(0) }
 
     val webViewClient = remember {
         object : WebViewClient() {
@@ -249,7 +252,7 @@ fun WebUiScreen(onExit: () -> Unit) {
                     try {
                         context.startActivity(Intent(Intent.ACTION_VIEW, uri))
                     } catch (_: ActivityNotFoundException) {
-                        showBrowserAlert = true
+                        showAlert = R.string.alert_browser_not_found
                     }
                     return true
                 }
@@ -265,6 +268,38 @@ fun WebUiScreen(onExit: () -> Unit) {
                 val isTv = context.packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
                 Log.d(TAG, "Initializing webview bridge with TV mode: $isTv")
                 bridgeInit(isTv)
+            }
+
+            override fun onLoadResource(view: WebView?, url: String?) {
+                val uri = Uri.parse(url)
+                val guiUri = guiUri!!
+
+                if (uri.scheme == guiUri.scheme
+                    && uri.host == guiUri.host
+                    && uri.port == guiUri.port
+                    && uri.path == "/rest/debug/support") {
+                    // We don't support downloading. DownloadListener is a terrible API that doesn't
+                    // support reading the response to the current request. Using that to feed the
+                    // download URL to download manager would cause two support bundles to be
+                    // created. Instead, we'll just open the directory containing the support
+                    // bundles. Since AOSP's FileSystemProvider uses inotify to notify clients to
+                    // refresh, it doesn't matter that we open the file manager before the HTTP
+                    // request completes.
+                    try {
+                        val externalDir = Environment.getExternalStorageDirectory()
+                        val filesDir = context.getExternalFilesDir(null)!!
+                        val relPath = filesDir.relativeTo(externalDir)
+                        val uri = DocumentsContract.buildDocumentUri(
+                            DOCUMENTSUI_AUTHORITY, "primary:$relPath")
+                        val intent = Intent(Intent.ACTION_VIEW).apply {
+                            setDataAndType(uri, "vnd.android.document/directory")
+                        }
+
+                        context.startActivity(intent)
+                    } catch (_: ActivityNotFoundException) {
+                        showAlert = R.string.alert_documentsui_not_found
+                    }
+                }
             }
 
             override fun doUpdateVisitedHistory(view: WebView, url: String, isReload: Boolean) {
@@ -311,15 +346,15 @@ fun WebUiScreen(onExit: () -> Unit) {
             },
         )
 
-        if (showBrowserAlert) {
-            val message = stringResource(R.string.alert_browser_not_found)
+        if (showAlert != 0) {
+            val message = stringResource(showAlert)
 
             LaunchedEffect(Unit) {
                 params.snackbarHostState.showSnackbar(
                     message = message,
                     withDismissAction = true,
                 )
-                showBrowserAlert = false
+                showAlert = 0
             }
         }
     }

--- a/stbridge/stbridge.go
+++ b/stbridge/stbridge.go
@@ -58,39 +58,47 @@ func Version() string {
 func cleanOldFiles() {
 	// We only clean up a subset of what upstream syncthing does since the
 	// initial release started with 2.x and certain features aren't enabled.
-	globs := map[string]time.Duration{
-		"panic-*.log":      7 * 24 * time.Hour,
-		"config.xml.v*":    30 * 24 * time.Hour,
-		"support-bundle-*": 30 * 24 * time.Hour,
+	locationGlobs := map[string]map[string]time.Duration{
+		locations.GetBaseDir(locations.ConfigBaseDir): map[string]time.Duration{
+			"panic-*.log":   7 * 24 * time.Hour,
+			"config.xml.v*": 30 * 24 * time.Hour,
+			// From before version 2.3.
+			"support-bundle-*": 30 * 24 * time.Hour,
+		},
+		locations.GetBaseDir(locations.SupportBundleBaseDir): map[string]time.Duration{
+			"support-bundle-*": 30 * 24 * time.Hour,
+		},
 	}
 
-	configFs := fs.NewFilesystem(fs.FilesystemTypeBasic, locations.GetBaseDir(locations.ConfigBaseDir))
+	for baseDir, globs := range locationGlobs {
+		baseFs := fs.NewFilesystem(fs.FilesystemTypeBasic, baseDir)
 
-	for glob, dur := range globs {
-		entries, err := configFs.Glob(glob)
-		if err != nil {
-			log.Printf("Failed to match glob: %q: %v", glob, err)
-			continue
-		}
-
-		for _, entry := range entries {
-			info, err := configFs.Lstat(entry)
+		for glob, dur := range globs {
+			entries, err := baseFs.Glob(glob)
 			if err != nil {
-				log.Printf("Failed to stat config: %q: %v", entry, err)
+				log.Printf("Failed to match glob: %q: %v", glob, err)
 				continue
 			}
 
-			if time.Since(info.ModTime()) <= dur {
-				log.Printf("Skipped deleting old config: %q", entry)
-				continue
-			}
+			for _, entry := range entries {
+				info, err := baseFs.Lstat(entry)
+				if err != nil {
+					log.Printf("Failed to stat file: %q: %v", entry, err)
+					continue
+				}
 
-			if err = configFs.RemoveAll(entry); err != nil {
-				log.Printf("Failed to delete old config: %q: %v", entry, err)
-				continue
-			}
+				if time.Since(info.ModTime()) <= dur {
+					log.Printf("Skipped deleting old file: %q", entry)
+					continue
+				}
 
-			log.Printf("Deleted old config: %q: %v", entry, err)
+				if err = baseFs.RemoveAll(entry); err != nil {
+					log.Printf("Failed to delete old file: %q: %v", entry, err)
+					continue
+				}
+
+				log.Printf("Deleted old file: %q: %v", entry, err)
+			}
 		}
 	}
 }
@@ -178,7 +186,7 @@ func SetLogLevel(level string) error {
 	return nil
 }
 
-func InitDirs(filesDir string, cacheDir string) error {
+func InitDirs(filesDir string, cacheDir string, externalDir string) error {
 	stLock.Lock()
 	defer stLock.Unlock()
 
@@ -187,6 +195,8 @@ func InitDirs(filesDir string, cacheDir string) error {
 		return fmt.Errorf("failed to set config directory: %w", err)
 	} else if err := locations.SetBaseDir(locations.DataBaseDir, configDir); err != nil {
 		return fmt.Errorf("failed to set data directory: %w", err)
+	} else if err := locations.SetBaseDir(locations.SupportBundleBaseDir, externalDir); err != nil {
+		return fmt.Errorf("failed to set support bundle directory: %w", err)
 	}
 	log.Print(locations.PrettyPaths())
 


### PR DESCRIPTION
Otherwise, the feature is completely useless as the user has no way to get the actual file besides connecting to the web UI with an actual browser.

This requires a couple minor changes to our Syncthing fork to allow writing support bundles to a separate directory and also to make them group-readable and writable.