### PR TITLE
Reduce minimum API level to 26

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -131,7 +131,7 @@ android {
 
     defaultConfig {
         applicationId = "com.chiller3.basicsync"
-        minSdk = 28
+        minSdk = 26
         targetSdk = 36
         versionCode = gitVersionCode
         versionName = gitVersionName

--- a/app/src/main/java/com/chiller3/basicsync/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/SettingsScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.content.ContextCompat
 import androidx.core.content.IntentCompat
 import androidx.core.content.PackageManagerCompat
 import androidx.core.content.UnusedAppRestrictionsConstants
@@ -479,7 +480,7 @@ fun SettingsScreen(
             }
 
             appHibernationDisabled = !enabled
-        }, context.mainExecutor)
+        }, ContextCompat.getMainExecutor(context))
 
         onDispose {
             future.cancel(true)

--- a/app/src/main/java/com/chiller3/basicsync/settings/WebUiScreen.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/WebUiScreen.kt
@@ -28,6 +28,7 @@ import android.webkit.WebViewClient
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -35,6 +36,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
@@ -73,6 +75,20 @@ private fun jsEscape(s: String) = buildString {
 fun WebUiScreen(onExit: () -> Unit) {
     val context = LocalContext.current
     val resources = LocalResources.current
+
+    val isTv = remember { context.packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK) }
+    val edgeToEdge = remember {
+        !isTv && run {
+            val majorVersion = WebView.getCurrentWebViewPackage()
+                ?.versionName
+                ?.substringBefore('.')
+                ?.toIntOrNull()
+            Log.d(TAG, "WebView major version: $majorVersion")
+
+            // https://developer.android.com/develop/ui/views/layout/webapps/understand-window-insets#feature-compatibility
+            if (majorVersion != null) majorVersion >= 144 else true
+        }
+    }
 
     // We intentionally do not use WebView.saveState() and WebView.restoreState(). It only supports
     // saving the back/forward history, which is pointless for the Syncthing web UI because it is an
@@ -137,8 +153,8 @@ fun WebUiScreen(onExit: () -> Unit) {
         webView.evaluateJavascript("onDeviceIdScanned(\"${jsEscape(deviceId)}\");") {}
     }
 
-    fun bridgeInit(isTv: Boolean) {
-        webView.evaluateJavascript("bridgeInit($isTv);") {}
+    fun bridgeInit(isTv: Boolean, edgeToEdge: Boolean) {
+        webView.evaluateJavascript("bridgeInit($isTv, $edgeToEdge);") {}
     }
 
     fun closeAllDropdowns() {
@@ -277,9 +293,8 @@ fun WebUiScreen(onExit: () -> Unit) {
 
                 view.evaluateJavascript(script) {}
 
-                val isTv = context.packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
-                Log.d(TAG, "Initializing webview bridge with TV mode: $isTv")
-                bridgeInit(isTv)
+                Log.d(TAG, "Initializing bridge: isTv=$isTv, edgeToEdge=$edgeToEdge")
+                bridgeInit(isTv, edgeToEdge)
             }
 
             override fun onLoadResource(view: WebView?, url: String?) {
@@ -355,6 +370,11 @@ fun WebUiScreen(onExit: () -> Unit) {
             },
             onRelease = {
                 it.destroy()
+            },
+            modifier = if (edgeToEdge) {
+                Modifier
+            } else {
+                Modifier.padding(paddingValues = params.contentPadding)
             },
         )
 

--- a/app/src/main/res/raw/webview_bridge.js
+++ b/app/src/main/res/raw/webview_bridge.js
@@ -207,7 +207,7 @@ function closeTopModal() {
     }
 }
 
-function bridgeInit(isTv) {
+function bridgeInit(isTv, edgeToEdge) {
     if (!tryMutate(isTv)) {
         const callback = (mutationList, observer) => {
             // The actual elements we need are added via innerHTML by Angular, which doesn't get
@@ -277,7 +277,9 @@ function bridgeInit(isTv) {
         const style = document.createElement('style');
         style.innerHTML = ':focus { border: 3px dotted !important; }';
         document.body.appendChild(style);
-    } else {
+    }
+
+    if (edgeToEdge) {
         // We use the bootstrap nav bar as the app nav bar, so don't let it get scrolled away.
         const nav = document.getElementsByTagName('nav')[0];
         nav.classList.remove('navbar-top');


### PR DESCRIPTION
We need to do a `WebView` major version check now because Android 8.0 is forever stuck on 138 after Google dropped support for older versions of Android. Only 144 and newer support the insets we need for edge-to-edge.

The only thing that is broken is launching DocumentsUI with a specific directory. There was an upstream bug that wasn't fixed until Android 10 that results in DocumentsUI crashing:

https://android.googlesource.com/platform/packages/apps/DocumentsUI/+/ec40c5c00cad98ad61626150fcf9d1cf505de38c

Fixes: #165