### PR TITLE
syncthing: Enable inotify on x86_64

### DIFF
--- a/stbridge/go.mod
+++ b/stbridge/go.mod
@@ -6,10 +6,13 @@ require (
 	github.com/syncthing/syncthing v0.0.0
 	go.foxforensics.dev/go-zip v0.6.2
 	golang.org/x/mobile v0.0.0-20260602190626-68735029466e
-	golang.org/x/sys v0.45.0
+	golang.org/x/sys v0.46.0
 )
 
-replace github.com/syncthing/syncthing v0.0.0 => ../external/syncthing
+replace (
+	github.com/syncthing/syncthing v0.0.0 => ../external/syncthing
+	golang.org/x/sys v0.46.0 => github.com/chenxiaolong/golang-x-sys v0.46.0-basicsync.0
+)
 
 require (
 	github.com/AudriusButkevicius/recli v0.0.7 // indirect

--- a/stbridge/go.sum
+++ b/stbridge/go.sum
@@ -23,6 +23,8 @@ github.com/ccding/go-stun v0.1.5 h1:qEM367nnezmj7dv+SdT52prv5x6HUTG3nlrjX5aitlo=
 github.com/ccding/go-stun v0.1.5/go.mod h1:cCZjJ1J3WFSJV6Wj8Y9Di8JMTsEXh6uv2eNmLzKaUeM=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chenxiaolong/golang-x-sys v0.46.0-basicsync.0 h1:BZg6xHZnIz0L5LjGeWZSSiQxVBUzeeVuiE00hVsb4S0=
+github.com/chenxiaolong/golang-x-sys v0.46.0-basicsync.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -263,8 +265,6 @@ golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
-golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Upstream Syncthing currently disables inotify on Android x86_64 because it uses `golang.org/x/sys`'s `unix.EpollWait` function, which is implemented in terms of `epoll_wait` on x86_64. That syscall is blocked by Android's x86_64 seccomp policy.

I've reported this at https://github.com/golang/go/issues/80080, but in the meantime, we can temporarily fork the `golang.org/x/sys` package to make it use `epoll_pwait` (same as what bionic libc does) on x86_64.

This allow file watchers to work in the Android emulator.