### PR TITLE
Add support for external storage via SAF

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The app is intentionally kept very basic so that the project is easy to maintain
 
 ## Features
 
-* Supports Android 9 and newer
+* Supports Android 8 and newer
+* Supports folders on [external storage](#external-storage)
 * Supports importing and exporting the configuration
 * Supports pausing syncing based on network and battery conditions
 * Supports Android's HTTP proxy settings
@@ -18,14 +19,6 @@ The app is intentionally kept very basic so that the project is easy to maintain
     * This makes BasicSync immune to Android >=12's child process restrictions
 * Small additions to Syncthing's web UI to add a folder picker and QR code scanner
 * Detects and reports sync conflicts
-
-## Limitations
-
-* Android's Storage Access Framework is not supported. While, with effort, it's possible to implement a custom filesystem backend for Syncthing, SAF is not well suited for Syncthing's file access patterns.
-
-    * Accessing files by path is extremely expensive. For example, accessing `a/b/c` requires `stat`ing every file in directories `a` and `b`. This is unavoidable without caching.
-    * Syncthing is much more efficient when it can monitor for changes with inotify-style watchers. While it is technically possible to monitor for changes to directories with SAF, it does not report what changed. Computing the changes is an expensive operation. SAF also does not support watching files, only directories.
-    * Creating and opening files are two separate operations, which can result in concurrency issues and file conflicts. Furthermore, attempting to create a file that already exists results in Android creating a new file with a numbered suffix instead of returning an error.
 
 ## Usage
 
@@ -71,6 +64,34 @@ The app is intentionally kept very basic so that the project is easy to maintain
 Syncthing listens on the loopback interface and is available via `127.0.0.1:8384` by default. BasicSync will try to use the same port on every start, but will automatically pick a new random port if there is a conflict. The current port number can be found in Web UI -> Actions -> Settings -> GUI. HTTPS and basic authentication are both forcibly enabled every time Syncthing starts.
 
 For basic authentication, the password is the API token. Generating new API tokens is supported, but setting an arbitrary password is not. BasicSync will internally set the password to the API token on every start.
+
+## External storage
+
+BasicSync supports syncing files on external storage via Android's Storage Access Framework (SAF). This is primarily intended for use with SD cards and USB drives, but can work with well-behaved third party SAF provider apps as well.
+
+Where possible, sync to internal storage instead. Using external storage is discouraged because SAF is not well suited for how Syncthing accesses files.
+
+* Accessing files by path is extremely inefficient. For example, it is not possible to directly access a nested file like `a/b/c`. Instead, Android will list every file in `a` and `b` and query their metadata before `c` is accessible. To reduce the impact of this, BasicSync caches directory listings and file metadata, but it will still be significantly slower than internal storage.
+
+* SAF cannot report any watcher events more specific than "some file changed in this folder". When a file is changed, Syncthing needs to rescan the folder it's stored in instead of just the file. That said, leaving file watchers enabled is generally still a good idea if files aren't being frequently changed.
+
+* SAF cannot guarantee that a creating a file will have the expected filename. When multiple processes try to create the same file at the same time, `file.txt` may be created as, for example, `file (1).txt`. BasicSync tries to reduce the chance of this happening within Syncthing, but it cannot protect from other apps writing to the same files.
+
+When using external storage, there is higher chance of running into unexpected sync errors. If they occur, wait 5 minutes for BasicSync's caches to expire and then trigger a rescan of the folder from Syncthing's web UI. Due to SAF's limitations, this is the best that can be done.
+
+**NOTE**: External storage support is a BasicSync feature, not a Syncthing feature. BasicSync has a large amount of code for bridging Syncthing's custom filesystem support to SAF. This means if the Syncthing config is exported from BasicSync and imported into another app, folders on external storage will not work properly.
+
+### SAF custom filesystem scheme
+
+For developers of other Syncthing apps, the custom filesystem scheme that BasicSync uses is:
+
+* Filesystem type: `saf`
+* Filesystem initialization path: `<URL-encoded SAF tree URI>[/<subpath>]`
+    * The SAF tree URI is the `content://<authority>/tree/<document ID>` URI returned by Android's `ACTION_OPEN_DOCUMENT_TREE` folder selector.
+    * The SAF tree URI is URL-encoded to prevent forward slashes from being included, while keeping the string relatively human-readable. It must not have forward slashes because Syncthing uses `filepath` APIs on the string and the URI must never be split apart since it's an opaque value.
+    * When initialized with an empty string, a virtual root directory is returned containing one child entry for each of the persisted SAF URIs that the user has granted permissions to. The children's names are the URL-encoding of each persisted URI, the same as if the custom filesystem was initialized for that URI.
+    * If a subpath is present, it represents a relative path within the SAF tree indicated by the first path component.
+    * Supporting both the empty path and also subpaths allows Syncthing's `/rest/system/browse?filesystem=saf` API endpoint to work.
 
 ## Remote control
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -464,8 +464,11 @@ val stbridge = tasks.register("stbridge") {
     inputs.files(
         goModFile,
         File(stbridgeSrcDir, "go.sum"),
+        File(stbridgeSrcDir, "saf.go"),
+        File(stbridgeSrcDir, "saf_test.go"),
         File(stbridgeSrcDir, "stbridge.go"),
         File(File(stbridgeSrcDir, "pidfdhack"), "pidfdhack.go"),
+        File(File(stbridgeSrcDir, "pidfdhack"), "pidfdhack_android.go"),
         File(syncthingGitDir, "HEAD"),
         golang.map { it.outputs.files },
         goenv.map { it.outputs.files },
@@ -520,6 +523,15 @@ val stbridge = tasks.register("stbridge") {
             addGoEnvironment(this)
 
             workingDir(syncthingDir)
+        }
+
+        injected.execOps.exec {
+            executable(goExecutable)
+            args("test", "-ldflags=-checklinkname=0")
+            environment("PATH", "$binDir${File.pathSeparator}${environment["PATH"]}")
+            addGoEnvironment(this)
+
+            workingDir(stbridgeSrcDir)
         }
 
         injected.execOps.exec {

--- a/app/src/main/java/com/chiller3/basicsync/MainApplication.kt
+++ b/app/src/main/java/com/chiller3/basicsync/MainApplication.kt
@@ -8,6 +8,7 @@ package com.chiller3.basicsync
 import android.app.Application
 import android.util.Log
 import com.chiller3.basicsync.binding.stbridge.Stbridge
+import com.chiller3.basicsync.syncthing.SyncthingSafClient
 import java.io.File
 
 class MainApplication : Application() {
@@ -41,5 +42,6 @@ class MainApplication : Application() {
             cacheDir.toString(),
             getExternalFilesDir(null)!!.toString(),
         )
+        Stbridge.setSafClient(SyncthingSafClient(this))
     }
 }

--- a/app/src/main/java/com/chiller3/basicsync/settings/ConflictsScreen.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/ConflictsScreen.kt
@@ -8,6 +8,7 @@ package com.chiller3.basicsync.settings
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.res.Configuration
+import android.net.Uri
 import android.provider.DocumentsContract
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -51,6 +52,8 @@ fun ConflictsScreen(
 
     rememberServiceEventWatcher(
         listener = object : SyncthingService.ServiceListener {
+            override fun onMissingStoragePermissions(internal: Boolean, external: List<Uri>) {}
+
             override fun onExitRequested() = onExit()
 
             override fun onRunStateChanged(

--- a/app/src/main/java/com/chiller3/basicsync/settings/ServiceEventWatcher.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/ServiceEventWatcher.kt
@@ -8,6 +8,7 @@ package com.chiller3.basicsync.settings
 import android.content.ComponentName
 import android.content.Context
 import android.content.ServiceConnection
+import android.net.Uri
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
@@ -82,6 +83,10 @@ class ServiceEventWatcher internal constructor(
     private fun onBinderGone() {
         binder?.unregisterListener(this)
         binder = null
+    }
+
+    override fun onMissingStoragePermissions(internal: Boolean, external: List<Uri>) {
+        handler.post { listener.onMissingStoragePermissions(internal, external) }
     }
 
     override fun onExitRequested() {

--- a/app/src/main/java/com/chiller3/basicsync/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/SettingsScreen.kt
@@ -12,6 +12,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.content.res.Configuration
+import android.net.Uri
 import android.os.BatteryManager
 import android.os.Build
 import android.provider.Settings
@@ -52,6 +53,7 @@ import com.chiller3.basicsync.Permissions
 import com.chiller3.basicsync.Preferences
 import com.chiller3.basicsync.R
 import com.chiller3.basicsync.binding.stbridge.Stbridge
+import com.chiller3.basicsync.extension.DOCUMENTSUI_AUTHORITY
 import com.chiller3.basicsync.extension.formattedString
 import com.chiller3.basicsync.syncthing.BlockedReason
 import com.chiller3.basicsync.syncthing.SyncthingService
@@ -114,7 +116,6 @@ fun SettingsScreen(
     val notificationsGranted = remember(reloadPerms) {
         Permissions.have(context, Permissions.NOTIFICATION)
     }
-    val localStorageAccess = remember(reloadPerms) { Permissions.haveLocalStorage(context) }
     // Hide this while loading to avoid jank in the usual case.
     var appHibernationDisabled by rememberSaveable { mutableStateOf(true) }
 
@@ -126,6 +127,20 @@ fun SettingsScreen(
     val serviceState by viewModel.serviceState.collectAsStateWithLifecycle()
     val conflicts by viewModel.conflicts.collectAsStateWithLifecycle()
     val importExportState by viewModel.importExportState.collectAsStateWithLifecycle()
+
+    var storagePermissionRequest by rememberSaveable { mutableStateOf(false) }
+    fun renotifyOrRestartService() {
+        // For storage permissions, we need Syncthing to restart so that it can reevaluate required
+        // permissions based on what folders are configured.
+        val action = if (storagePermissionRequest) {
+            storagePermissionRequest = false
+            SyncthingService.ACTION_RECHECK
+        } else {
+            SyncthingService.ACTION_RENOTIFY
+        }
+
+        SyncthingService.start(context, action)
+    }
 
     val requestInhibitBatteryOpt = rememberLauncherForActivityResult(
         ActivityResultContracts.StartActivityForResult(),
@@ -139,22 +154,25 @@ fun SettingsScreen(
     val requestPermissionActivity = rememberLauncherForActivityResult(
         ActivityResultContracts.StartActivityForResult(),
     ) {
-        // Needed for the local storage permission. We intentionally don't check resultCode here
-        // because going back to the app after granting the permission results in RESULT_CANCELED.
-        SyncthingService.start(context, SyncthingService.ACTION_RENOTIFY)
-
+        renotifyOrRestartService()
         reloadPerms++
     }
     val requestPermissionsRequired = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions(),
     ) { granted ->
         if (granted.all { it.value }) {
-            // Resend service notification so that the user can actually interact with the service.
-            SyncthingService.start(context, SyncthingService.ACTION_RENOTIFY)
-
+            renotifyOrRestartService()
             reloadPerms++
         } else {
             requestPermissionActivity.launch(Permissions.getAppInfoIntent(context))
+        }
+    }
+    val requestSafExternalStorage = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocumentTree()
+    ) { uri ->
+        uri?.let {
+            SyncthingService.persistExternalStoragePermissions(context, it)
+            renotifyOrRestartService()
         }
     }
     val requestSafImportConfiguration = rememberLauncherForActivityResult(
@@ -179,8 +197,16 @@ fun SettingsScreen(
         }
     }
 
+    var missingInternal by rememberSaveable { mutableStateOf(false) }
+    var missingExternal by rememberSaveable { mutableStateOf(emptyList<Uri>()) }
+
     val watcher = rememberServiceEventWatcher(
         listener = object : SyncthingService.ServiceListener {
+            override fun onMissingStoragePermissions(internal: Boolean, external: List<Uri>) {
+                missingInternal = internal
+                missingExternal = external
+            }
+
             override fun onExitRequested() = onExit()
 
             override fun onRunStateChanged(
@@ -286,8 +312,9 @@ fun SettingsScreen(
             importExportState = importExportState,
             inhibitBatteryOpt = inhibitBatteryOpt,
             notificationsGranted = notificationsGranted,
-            localStorageAccess = localStorageAccess,
             appHibernationDisabled = appHibernationDisabled,
+            missingInternal = missingInternal,
+            missingExternal = missingExternal,
             conflicts = conflicts ?: emptyList(),
             isManualMode = isManualMode,
             hasBattery = hasBattery,
@@ -306,7 +333,17 @@ fun SettingsScreen(
             onNotificationsGrant = {
                 requestPermissionsRequired.launch(Permissions.NOTIFICATION)
             },
-            onLocalStorageAccessGrant = {
+            onAppHibernationDisable = {
+                requestPermissionActivity.launch(
+                    IntentCompat.createManageUnusedAppRestrictionsIntent(
+                        context,
+                        context.packageName,
+                    )
+                )
+            },
+            onInternalStorageGrant = {
+                storagePermissionRequest = true
+
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                     val intent = Intent(
                         Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
@@ -318,13 +355,9 @@ fun SettingsScreen(
                     requestPermissionsRequired.launch(Permissions.LEGACY_STORAGE)
                 }
             },
-            onAppHibernationDisable = {
-                requestPermissionActivity.launch(
-                    IntentCompat.createManageUnusedAppRestrictionsIntent(
-                        context,
-                        context.packageName,
-                    )
-                )
+            onExternalStorageGrant = { uri ->
+                storagePermissionRequest = true
+                requestSafExternalStorage.launch(uri)
             },
             onConflictsOpen = {
                 context.startActivity(Intent(context, ConflictsActivity::class.java))
@@ -495,8 +528,9 @@ private fun SettingsContent(
     importExportState: ImportExportState?,
     inhibitBatteryOpt: Boolean,
     notificationsGranted: Boolean,
-    localStorageAccess: Boolean,
     appHibernationDisabled: Boolean,
+    missingInternal: Boolean,
+    missingExternal: List<Uri>,
     conflicts: List<String>,
     isManualMode: Boolean,
     hasBattery: Boolean,
@@ -511,8 +545,9 @@ private fun SettingsContent(
     isDebugMode: Boolean,
     onInhibitBatteryOptGrant: () -> Unit,
     onNotificationsGrant: () -> Unit,
-    onLocalStorageAccessGrant: () -> Unit,
     onAppHibernationDisable: () -> Unit,
+    onInternalStorageGrant: () -> Unit,
+    onExternalStorageGrant: (Uri) -> Unit,
     onConflictsOpen: () -> Unit,
     onWebUiOpen: () -> Unit,
     onConfigurationImport: () -> Unit,
@@ -558,20 +593,28 @@ private fun SettingsContent(
                 onGrant = onNotificationsGrant,
             ))
         }
-        if (!localStorageAccess) {
-            add(MissingPermission(
-                key = "local_storage_access",
-                title = stringResource(R.string.pref_local_storage_access_name),
-                summary = stringResource(R.string.pref_local_storage_access_desc),
-                onGrant = onLocalStorageAccessGrant,
-            ))
-        }
         if (!appHibernationDisabled) {
             add(MissingPermission(
                 key = "disable_app_hibernation",
                 title = stringResource(R.string.pref_disable_app_hibernation_name),
                 summary = stringResource(R.string.pref_disable_app_hibernation_desc),
                 onGrant = onAppHibernationDisable,
+            ))
+        }
+        if (missingInternal) {
+            add(MissingPermission(
+                key = "missing_internal",
+                title = stringResource(R.string.pref_local_storage_access_name),
+                summary = stringResource(R.string.pref_local_storage_access_desc),
+                onGrant = onInternalStorageGrant,
+            ))
+        }
+        for (uri in missingExternal) {
+            add(MissingPermission(
+                key = "missing_external:$uri",
+                title = stringResource(R.string.pref_external_storage_access),
+                summary = uri.formattedString,
+                onGrant = { onExternalStorageGrant(uri) },
             ))
         }
     }
@@ -939,8 +982,9 @@ private fun PreviewSettingsScreen() {
                 importExportState = null,
                 inhibitBatteryOpt = false,
                 notificationsGranted = false,
-                localStorageAccess = false,
                 appHibernationDisabled = false,
+                missingInternal = true,
+                missingExternal = listOf("content://${DOCUMENTSUI_AUTHORITY}/tree/primary%3afile".toUri()),
                 conflicts = listOf(""),
                 isManualMode = false,
                 hasBattery = true,
@@ -955,8 +999,9 @@ private fun PreviewSettingsScreen() {
                 isDebugMode = true,
                 onInhibitBatteryOptGrant = {},
                 onNotificationsGrant = {},
-                onLocalStorageAccessGrant = {},
                 onAppHibernationDisable = {},
+                onInternalStorageGrant = {},
+                onExternalStorageGrant = {},
                 onConflictsOpen = {},
                 onWebUiOpen = {},
                 onConfigurationImport = {},

--- a/app/src/main/java/com/chiller3/basicsync/settings/StorageChoiceDialog.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/StorageChoiceDialog.kt
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.basicsync.settings
+
+import android.os.Parcelable
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.chiller3.basicsync.R
+import com.chiller3.basicsync.ui.Preference
+import com.chiller3.basicsync.ui.PreferenceColumn
+import com.chiller3.basicsync.ui.betterSegmentedShapes
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+enum class StorageChoice : Parcelable {
+    INTERNAL,
+    EXTERNAL,
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun StorageChoiceDialog(
+    onSelect: (StorageChoice) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        title = { Text(text = stringResource(R.string.dialog_storage_type_title)) },
+        text = {
+            val choices = StorageChoice.entries
+
+            PreferenceColumn(fillScreen = false) {
+                itemsIndexed(choices) { index, choice ->
+                    val title = when (choice) {
+                        StorageChoice.INTERNAL ->
+                            stringResource(R.string.dialog_storage_type_internal_title)
+                        StorageChoice.EXTERNAL ->
+                            stringResource(R.string.dialog_storage_type_external_title)
+                    }
+                    val summary = when (choice) {
+                        StorageChoice.INTERNAL ->
+                            stringResource(R.string.dialog_storage_type_internal_desc)
+                        StorageChoice.EXTERNAL ->
+                            stringResource(R.string.dialog_storage_type_external_desc)
+                    }
+
+                    Preference(
+                        onClick = { onSelect(choice) },
+                        shapes = betterSegmentedShapes(index = index, count = choices.size),
+                        title = { Text(text = title) },
+                        summary = { Text(text = summary) },
+                    )
+                }
+            }
+        },
+        onDismissRequest = onDismiss,
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(android.R.string.cancel))
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/chiller3/basicsync/settings/WebUiScreen.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/WebUiScreen.kt
@@ -16,6 +16,7 @@ import android.net.http.SslError
 import android.os.Build
 import android.os.Environment
 import android.provider.DocumentsContract
+import android.provider.Settings
 import android.util.Base64
 import android.util.Log
 import android.view.ViewGroup
@@ -43,6 +44,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.net.toUri
 import androidx.lifecycle.compose.LifecycleResumeEffect
+import com.chiller3.basicsync.BuildConfig
+import com.chiller3.basicsync.Permissions
 import com.chiller3.basicsync.R
 import com.chiller3.basicsync.extension.DOCUMENTSUI_AUTHORITY
 import com.chiller3.basicsync.syncthing.SyncthingService
@@ -108,6 +111,8 @@ fun WebUiScreen(onExit: () -> Unit) {
     var guiCert by remember { mutableStateOf<X509Certificate?>(null) }
     rememberServiceEventWatcher(
         listener = object : SyncthingService.ServiceListener {
+            override fun onMissingStoragePermissions(internal: Boolean, external: List<Uri>) {}
+
             override fun onExitRequested() = onExit()
 
             override fun onRunStateChanged(
@@ -145,8 +150,8 @@ fun WebUiScreen(onExit: () -> Unit) {
         },
     )
 
-    fun onFolderSelected(path: String) {
-        webView.evaluateJavascript("onFolderSelected(\"${jsEscape(path)}\");") {}
+    fun onFolderSelected(type: String, path: String) {
+        webView.evaluateJavascript("onFolderSelected(\"${jsEscape(type)}\", \"${jsEscape(path)}\");") {}
     }
 
     fun onDeviceIdScanned(deviceId: String) {
@@ -189,14 +194,94 @@ fun WebUiScreen(onExit: () -> Unit) {
         }
     }
 
-    // This intentionally does not use rememberSaveable because the WebView would reload anyway if
-    // the Activity was recreated.
+    // The dialogs intentionally do not use rememberSaveable because the WebView would reload anyway
+    // if the Activity was recreated.
+    var showStorageTypeDialog by remember { mutableStateOf(false) }
     var showFolderPickerDialog by remember { mutableStateOf<FolderPickerLocation?>(null) }
+    var existingFolderPath by remember { mutableStateOf<String?>(null) }
+
+    fun showFolderPicker(alwaysClearExisting: Boolean): Boolean {
+        val havePermissions = Permissions.haveLocalStorage(context)
+
+        if (havePermissions) {
+            showFolderPickerDialog = existingFolderPath
+                ?.let(FolderPickerLocation::Path)
+                ?: FolderPickerLocation.Default
+        }
+
+        if (havePermissions || alwaysClearExisting) {
+            existingFolderPath = null
+        }
+
+        return havePermissions
+    }
+
+    val requestPermissionActivity = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) {
+        showFolderPicker(true)
+    }
+
+    val requestPermissionsRequired = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions(),
+    ) { granted ->
+        if (granted.all { it.value }) {
+            showFolderPicker(true)
+        } else {
+            requestPermissionActivity.launch(Permissions.getAppInfoIntent(context))
+        }
+    }
+
+    val requestSafExternalStorage = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocumentTree()
+    ) { uri ->
+        uri?.let {
+            SyncthingService.persistExternalStoragePermissions(context, it)
+
+            onFolderSelected("saf", SyncthingService.encodeSafUri(it))
+        }
+
+        existingFolderPath = null
+    }
+
+    if (showStorageTypeDialog) {
+        StorageChoiceDialog(
+            onSelect = { type ->
+                when (type) {
+                    StorageChoice.INTERNAL -> {
+                        if (showFolderPicker(false)) {
+                            // Already have permissions.
+                        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                            val intent = Intent(
+                                Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
+                                "package:${BuildConfig.APPLICATION_ID}".toUri(),
+                            )
+
+                            requestPermissionActivity.launch(intent)
+                        } else {
+                            requestPermissionsRequired.launch(Permissions.LEGACY_STORAGE)
+                        }
+                    }
+                    StorageChoice.EXTERNAL -> {
+                        requestSafExternalStorage.launch(existingFolderPath?.toUri())
+                        existingFolderPath = null
+                    }
+                }
+
+                showStorageTypeDialog = false
+            },
+            onDismiss = {
+                showStorageTypeDialog = false
+                existingFolderPath = null
+            },
+        )
+    }
+
     showFolderPickerDialog?.let { location ->
         FolderPickerDialog(
             initialLocation = location,
             onSelect = { shortPath ->
-                onFolderSelected(shortPath)
+                onFolderSelected("basic", shortPath)
                 showFolderPickerDialog = null
             },
             onDismiss = {
@@ -216,11 +301,22 @@ fun WebUiScreen(onExit: () -> Unit) {
             }
 
             @JavascriptInterface
-            fun openFolderPicker(path: String) {
-                showFolderPickerDialog = if (path.isNotEmpty()) {
-                    FolderPickerLocation.Path(path)
-                } else {
-                    FolderPickerLocation.Default
+            fun openFolderPicker(filesystemType: String, path: String) {
+                showStorageTypeDialog = true
+
+                if (path.isNotEmpty()) {
+                    when (filesystemType) {
+                        "basic" -> existingFolderPath = path
+                        "saf" -> {
+                            // DocumentsUI does not support tree URIs for EXTRA_INITIAL_URI.
+                            val treeUri = SyncthingService.decodeSafUri(path).first
+                            existingFolderPath = DocumentsContract.buildDocumentUri(
+                                treeUri.authority,
+                                DocumentsContract.getTreeDocumentId(treeUri),
+                            ).toString()
+                        }
+                        else -> Log.w(TAG, "Ignoring unrecognized filesystem type: $filesystemType")
+                    }
                 }
             }
 

--- a/app/src/main/java/com/chiller3/basicsync/syncthing/DeviceState.kt
+++ b/app/src/main/java/com/chiller3/basicsync/syncthing/DeviceState.kt
@@ -136,10 +136,6 @@ data class DeviceState(
     fun blockedReasons(context: Context, prefs: Preferences): EnumSet<BlockedReason> {
         val reasons = EnumSet.noneOf(BlockedReason::class.java)
 
-        if (!Permissions.haveLocalStorage(context)) {
-            reasons.add(BlockedReason.NO_STORAGE_PERMISSIONS)
-        }
-
         if (!isNetworkConnected) {
             Log.d(TAG, "Blocked due to lack of network connectivity")
             reasons.add(BlockedReason.DISCONNECTED)

--- a/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingSafClient.kt
+++ b/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingSafClient.kt
@@ -1,0 +1,213 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Andrew Gunnerson
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.chiller3.basicsync.syncthing
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.database.ContentObserver
+import android.database.Cursor
+import android.net.Uri
+import android.provider.DocumentsContract
+import androidx.core.net.toUri
+import com.chiller3.basicsync.binding.stbridge.SafChangeListener
+import com.chiller3.basicsync.binding.stbridge.SafClient
+import com.chiller3.basicsync.binding.stbridge.SafObserver
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.IOException
+
+class SyncthingSafClient(private val context: Context) : SafClient {
+    private fun Cursor.asSequence() = generateSequence(seed = takeIf { it.moveToFirst() }) {
+        takeIf { it.moveToNext() }
+    }
+
+    private fun <R> queryMetadataUri(uri: Uri, block: (Sequence<JSONObject>) -> R): R {
+        val cursor = context.contentResolver.query(
+            uri,
+            arrayOf(
+                DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+                DocumentsContract.Document.COLUMN_MIME_TYPE,
+                DocumentsContract.Document.COLUMN_SIZE,
+                DocumentsContract.Document.COLUMN_LAST_MODIFIED,
+            ),
+            null, null, null,
+        ) ?: throw IOException("Query returned null cursor: $uri")
+
+        return cursor.use {
+            val indexDocumentId =
+                cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DOCUMENT_ID)
+            val indexDisplayName =
+                cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DISPLAY_NAME)
+            val indexMimeType =
+                cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_MIME_TYPE)
+            val indexSize =
+                cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_SIZE)
+            val indexLastModified =
+                cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_LAST_MODIFIED)
+
+            block(cursor.asSequence().map {
+                val documentId = cursor.getString(indexDocumentId)
+                val displayName = cursor.getString(indexDisplayName)
+                val mimeType = cursor.getString(indexMimeType)
+                val size = cursor.getLong(indexSize)
+                val lastModified = cursor.getLong(indexLastModified)
+
+                val childUri = DocumentsContract.buildDocumentUriUsingTree(uri, documentId)
+
+                JSONObject()
+                    .put("uri", childUri.toString())
+                    .put("name", displayName)
+                    .put("size", size)
+                    .put("mtime", lastModified)
+                    .put("is_dir", mimeType == DocumentsContract.Document.MIME_TYPE_DIR)
+            })
+        }
+    }
+
+    private fun getNarrowestDocumentId(uri: Uri): String =
+        try {
+            DocumentsContract.getDocumentId(uri)
+        } catch (_: IllegalArgumentException) {
+            DocumentsContract.getTreeDocumentId(uri)
+        }
+
+    override fun toTreeDocumentUri(treeUri: String): String {
+        val uri = treeUri.toUri()
+        val documentUri = DocumentsContract.buildDocumentUriUsingTree(
+            uri,
+            getNarrowestDocumentId(uri),
+        )
+
+        return documentUri.toString()
+    }
+
+    override fun queryTreeRootsJson(): String {
+        return JSONArray()
+            .apply {
+                for (persisted in context.contentResolver.persistedUriPermissions) {
+                    if (!DocumentsContract.isTreeUri(persisted.uri)) {
+                        continue
+                    }
+
+                    put(persisted.uri.toString())
+                }
+            }
+            .toString()
+    }
+
+    override fun queryChildDocumentsJson(documentUri: String): String {
+        val uri = documentUri.toUri()
+        val childDocumentsUri = DocumentsContract.buildChildDocumentsUriUsingTree(
+            uri,
+            getNarrowestDocumentId(uri),
+        )
+
+        return JSONArray()
+            .apply {
+                queryMetadataUri(childDocumentsUri) { children ->
+                    children.forEach { put(it) }
+                }
+            }
+            .toString()
+    }
+
+    override fun queryDocumentJson(documentUri: String): String {
+        return queryMetadataUri(documentUri.toUri()) { it.first().toString() }
+    }
+
+    override fun openDocument(documentUri: String, mode: String): Long {
+        val uri = documentUri.toUri()
+
+        @SuppressLint("Recycle")
+        val pfd = context.contentResolver.openFileDescriptor(uri, mode)
+            ?: throw IOException("Failed to open fd: $uri")
+
+        // stbridge will own the fd.
+        return pfd.detachFd().toLong()
+    }
+
+    override fun createDocument(parentDocumentUri: String, mimeType: String, name: String): String {
+        val newDocumentUri = DocumentsContract.createDocument(
+            context.contentResolver,
+            parentDocumentUri.toUri(),
+            mimeType,
+            name,
+        ) ?: throw IOException("Failed to create file: $parentDocumentUri, $mimeType, $name")
+
+        return newDocumentUri.toString()
+    }
+
+    override fun renameDocument(documentUri: String, name: String): String {
+        val newDocumentUri = DocumentsContract.renameDocument(
+            context.contentResolver,
+            documentUri.toUri(),
+            name,
+        ) ?: throw IOException("Failed to rename file: $documentUri -> $name")
+
+        return newDocumentUri.toString()
+    }
+
+    override fun deleteDocument(documentUri: String) {
+        if (!DocumentsContract.deleteDocument(context.contentResolver, documentUri.toUri())) {
+            throw IOException("Failed to delete file: $documentUri")
+        }
+    }
+
+    override fun moveDocument(
+        sourceDocumentUri: String,
+        sourceParentDocumentUri: String,
+        targetParentDocumentUri: String,
+    ): String {
+        val newDocumentUri = DocumentsContract.moveDocument(
+            context.contentResolver,
+            sourceDocumentUri.toUri(),
+            sourceParentDocumentUri.toUri(),
+            targetParentDocumentUri.toUri(),
+        ) ?: throw IOException("Failed to move document: $sourceDocumentUri: $sourceParentDocumentUri -> $targetParentDocumentUri")
+
+        return newDocumentUri.toString()
+    }
+
+    override fun observeDocument(
+        documentUri: String,
+        changeListener: SafChangeListener,
+    ): SafObserver {
+        val uri = documentUri.toUri()
+        val childDocumentsUri = DocumentsContract.buildChildDocumentsUriUsingTree(
+            uri,
+            getNarrowestDocumentId(uri),
+        )
+
+        // For AOSP's FileSystemProvider, we need to keep the cursor alive or else it won't watch
+        // for inotify events.
+        val cursor = context.contentResolver.query(
+            childDocumentsUri,
+            arrayOf(DocumentsContract.Document.COLUMN_DOCUMENT_ID),
+            null, null, null,
+        ) ?: throw IOException("Query returned null cursor: $uri")
+
+        return Observer(cursor, changeListener)
+    }
+
+    private class Observer(
+        private val cursor: Cursor,
+        private val changeListener: SafChangeListener,
+    ) : ContentObserver(null), SafObserver {
+        init {
+            cursor.registerContentObserver(this)
+        }
+
+        override fun cancel() {
+            cursor.unregisterContentObserver(this)
+            cursor.close()
+        }
+
+        override fun onChange(selfChange: Boolean) {
+            changeListener.onChange()
+        }
+    }
+}

--- a/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
+++ b/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
@@ -15,11 +15,14 @@ import android.net.Uri
 import android.os.Binder
 import android.os.Build
 import android.os.IBinder
+import android.provider.DocumentsContract
 import android.util.Log
 import androidx.annotation.GuardedBy
 import androidx.annotation.WorkerThread
 import androidx.core.app.ServiceCompat
+import androidx.core.net.toUri
 import com.chiller3.basicsync.Notifications
+import com.chiller3.basicsync.Permissions
 import com.chiller3.basicsync.Preferences
 import com.chiller3.basicsync.binding.stbridge.Stbridge
 import com.chiller3.basicsync.binding.stbridge.SyncthingApp
@@ -47,6 +50,7 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
         val ACTION_START = "${SyncthingService::class.java.canonicalName}.start"
         val ACTION_STOP = "${SyncthingService::class.java.canonicalName}.stop"
         val ACTION_RENOTIFY = "${SyncthingService::class.java.canonicalName}.renotify"
+        val ACTION_RECHECK = "${SyncthingService::class.java.canonicalName}.restart"
         val ACTION_EXIT = "${SyncthingService::class.java.canonicalName}.exit"
 
         fun createIntent(context: Context, action: String?) =
@@ -56,6 +60,43 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
 
         fun start(context: Context, action: String?) {
             context.startForegroundService(createIntent(context, action))
+        }
+
+        private fun unpack0Sep(str0Sep: String): MutableList<String> =
+            mutableListOf<String>().apply {
+                if (str0Sep.isNotEmpty()) {
+                    str0Sep.splitToSequence('\u0000').toCollection(this)
+                }
+            }
+
+        fun encodeSafUri(uri: Uri, path: String? = null) = buildString {
+            append(Uri.encode(uri.toString()))
+
+            if (path != null) {
+                append('/')
+                append(path)
+            }
+        }
+
+        fun decodeSafUri(encoded: String): Pair<Uri, String?> {
+            val separator = encoded.indexOf('/')
+            val (uriEncoded, path) = if (separator < 0) {
+                encoded to null
+            } else {
+                encoded.substring(0, separator) to encoded.substring(separator + 1)
+            }
+            val uri = Uri.decode(uriEncoded).toUri()
+
+            return uri to path
+        }
+
+        fun persistExternalStoragePermissions(context: Context, uri: Uri) {
+            // Permissions are released in onCheckStoragePermissions() when unneeded.
+            context.contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION
+                        or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+            )
         }
     }
 
@@ -159,9 +200,13 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
     }
 
     sealed interface PreRunAction {
+        val needRecheck: Boolean
+
         fun perform(context: Context)
 
         data class Import(val uri: Uri, val password: Password) : PreRunAction {
+            override val needRecheck = true
+
             override fun perform(context: Context) {
                 @SuppressLint("Recycle")
                 val fd = context.contentResolver.openFileDescriptor(uri, "r")
@@ -173,6 +218,8 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
         }
 
         data class Export(val uri: Uri, val password: Password) : PreRunAction {
+            override val needRecheck = false
+
             override fun perform(context: Context) {
                 @SuppressLint("Recycle")
                 val fd = context.contentResolver.openFileDescriptor(uri, "wt")
@@ -234,6 +281,15 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
 
     @GuardedBy("stateLock")
     private var blockedReasons = EnumSet.noneOf(BlockedReason::class.java)
+
+    // We want to check permissions on startup, even if the user currently set Syncthing to be
+    // manually stopped.
+    @GuardedBy("stateLock")
+    private var recheckPermissions = true
+    @GuardedBy("stateLock")
+    private var missingInternal = false
+    @GuardedBy("stateLock")
+    private var missingExternal = emptyList<Uri>()
 
     @GuardedBy("stateLock")
     private var shouldThreadRun = true
@@ -355,7 +411,6 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.d(TAG, "Received intent: $intent")
 
-        var recomputeBlockedReasons = false
         var forceShowNotification = false
 
         when (intent?.action) {
@@ -383,10 +438,12 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
                 prefs.isManualMode = true
             }
             ACTION_RENOTIFY -> {
-                // Blocked reasons needs to be recomputed because this intent might be due to the
-                // local storage permissions being successfully granted.
-                recomputeBlockedReasons = true
                 forceShowNotification = true
+            }
+            ACTION_RECHECK -> {
+                synchronized(stateLock) {
+                    recheckPermissions = true
+                }
             }
             ACTION_EXIT -> {
                 allListeners { it.onExitRequested() }
@@ -398,10 +455,7 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
             else -> Log.w(TAG, "Ignoring unrecognized intent: $intent")
         }
 
-        stateChanged(
-            recomputeBlockedReasons = recomputeBlockedReasons,
-            forceShowNotification = forceShowNotification,
-        )
+        stateChanged(forceShowNotification = forceShowNotification)
 
         return START_STICKY
     }
@@ -461,6 +515,12 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
                         if (!prefs.manualShouldRun) {
                             add(BlockedReason.MANUAL)
                         }
+                    }
+
+                    // We intentionally only check internal storage permissions. See
+                    // onCheckStoragePermissions().
+                    if (missingInternal && !recheckPermissions) {
+                        add(BlockedReason.NO_STORAGE_PERMISSIONS)
                     }
                 }
             }
@@ -530,6 +590,7 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
         val needFullRestart = !shouldThreadRun
                 || runningProxyInfo != deviceState.proxyInfo
                 || preRunActions.isNotEmpty()
+                || recheckPermissions
 
         if (needFullRestart || isStarted != shouldStart || isResumed != shouldResume) {
             if (!needFullRestart && app != null && prefs.keepAlive) {
@@ -549,9 +610,10 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
         while (true) {
             val actions = ArrayList<PreRunAction>()
             var proxyInfo: ProxyInfo
+            var recheckOnly: Boolean
 
             synchronized(stateLock) {
-                while (preRunActions.isEmpty() && !shouldStart) {
+                while (preRunActions.isEmpty() && !shouldStart && !recheckPermissions) {
                     if (!shouldThreadRun) {
                         Log.d(TAG, "Service is exiting; shutting down")
                         return
@@ -566,6 +628,9 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
 
                 runningProxyInfo = deviceState.proxyInfo
                 proxyInfo = deviceState.proxyInfo
+
+                // recheckPermissions is cleared in onCheckStoragePermissions().
+                recheckOnly = !shouldStart
             }
 
             if (actions.isNotEmpty()) {
@@ -586,6 +651,10 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
                     }
 
                     synchronized(stateLock) {
+                        if (action.needRecheck) {
+                            recheckPermissions = true
+                        }
+
                         allListeners { it.onPreRunActionResult(action, exception) }
 
                         currentPreRunAction = null
@@ -603,6 +672,7 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
                     proxy = proxyInfo.proxy
                     noProxy = proxyInfo.noProxy
                     receiver = this@SyncthingService
+                    checkOnly = recheckOnly
                 })
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to run syncthing", e)
@@ -616,6 +686,61 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
                 prefs.isManualMode = true
 
                 // stateChanged() will be called by onSharedPreferenceChanged().
+            }
+        }
+    }
+
+    override fun onCheckStoragePermissions(internal0Sep: String, external0Sep: String) {
+        val external = mutableSetOf<Uri>()
+
+        for (encoded in unpack0Sep(external0Sep)) {
+            try {
+                external.add(decodeSafUri(encoded).first)
+            } catch (e: Exception) {
+                Log.w(TAG, "Ignoring invalid encoded URI: $encoded", e)
+            }
+        }
+
+        for (persisted in contentResolver.persistedUriPermissions) {
+            if (!DocumentsContract.isTreeUri(persisted.uri)) {
+                continue
+            }
+
+            if (!external.remove(persisted.uri)) {
+                Log.d(TAG, "Releasing persisted permission: $persisted")
+                try {
+                    var flags = 0
+                    if (persisted.isReadPermission) {
+                        flags = flags or Intent.FLAG_GRANT_READ_URI_PERMISSION
+                    }
+                    if (persisted.isWritePermission) {
+                        flags = flags or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                    }
+
+                    contentResolver.releasePersistableUriPermission(persisted.uri, flags)
+                } catch (e: Exception) {
+                    Log.w(TAG, "Failed to release persisted permission: $persisted", e)
+                }
+            }
+        }
+
+        synchronized(stateLock) {
+            recheckPermissions = false
+            missingInternal = internal0Sep.isNotEmpty() && !Permissions.haveLocalStorage(this)
+            missingExternal = external.sorted()
+
+            allListeners {
+                it.onMissingStoragePermissions(missingInternal, missingExternal)
+            }
+
+            stateChanged(recomputeBlockedReasons = true)
+
+            // We intentionally block on missing internal permissions only. If a SAF URI is
+            // inaccessible, Syncthing will completely lose access to it. However, if the local
+            // storage permission is denied, folders are still visible, so Syncthing thinks
+            // everything was deleted.
+            if (missingInternal) {
+                throw SecurityException("Missing internal storage permissions")
             }
         }
     }
@@ -648,14 +773,7 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
 
     @WorkerThread
     override fun onConflictsUpdated(paths0Sep: String) {
-        val paths = if (paths0Sep.isEmpty()) {
-            emptyList()
-        } else {
-            mutableListOf<String>().apply {
-                paths0Sep.splitToSequence('\u0000').toCollection(this)
-                sort()
-            }
-        }
+        val paths = unpack0Sep(paths0Sep).apply { sort() }
 
         synchronized(stateLock) {
             syncthingConflicts = paths
@@ -733,6 +851,8 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
     }
 
     interface ServiceListener {
+        fun onMissingStoragePermissions(internal: Boolean, external: List<Uri>)
+
         fun onExitRequested()
 
         fun onRunStateChanged(state: ServiceState, guiInfo: GuiInfo?)
@@ -751,6 +871,7 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
                     Log.w(TAG, "Listener was already registered: $listener")
                 }
 
+                listener.onMissingStoragePermissions(missingInternal, missingExternal)
                 listener.onRunStateChanged(lastServiceState!!, guiInfo)
                 listener.onConflictsUpdated(syncthingConflicts)
             }

--- a/app/src/main/res/raw/webview_bridge.js
+++ b/app/src/main/res/raw/webview_bridge.js
@@ -41,12 +41,40 @@ function addFolderPicker(element) {
     inputGroup.appendChild(buttonGroup);
 
     button.addEventListener('click', function () {
-        BasicSync.openFolderPicker(element.value);
+        const filesystemType = document.getElementById('filesystemType');
+
+        BasicSync.openFolderPicker(filesystemType.value, element.value);
     }, false);
 
     // Disable the builtin autocomplete. The popup renders very poorly on mobile, with the width
     // frequently being too narrow and it not opening at the correct position.
     element.removeAttribute('list');
+}
+
+function addFilesystemType(element) {
+    console.log('Adding filesystem type box to:', element);
+
+    // Depends on addFolderPicker() having run already.
+    const origInputGroup = element.parentElement;
+
+    const filesystemType = document.createElement('input');
+    filesystemType.id = 'filesystemType';
+    filesystemType.name = 'filesystemType';
+    filesystemType.type = 'text';
+    // Angular won't update the value if type=hidden.
+    filesystemType.style = 'display: none';
+    filesystemType.classList.add('form-control');
+    filesystemType.setAttribute('ng-model', 'currentFolder.filesystemType');
+    filesystemType.setAttribute('ng-readonly', 'editingFolderExisting()');
+    filesystemType.setAttribute('ng-required', '!editingFolderDefaults()');
+    filesystemType.setAttribute('ng-aria-required', '!editingFolderDefaults()');
+
+    angular.element(document).injector().invoke(function ($compile) {
+        const scope = angular.element(element).scope();
+        $compile(filesystemType)(scope);
+
+        origInputGroup.insertAdjacentElement('afterend', filesystemType);
+    });
 }
 
 function addQrScanner(element) {
@@ -137,6 +165,7 @@ function tryMutate(isTv) {
         elemFolderPath = document.getElementById('folderPath');
         if (elemFolderPath) {
             addFolderPicker(elemFolderPath);
+            addFilesystemType(elemFolderPath);
         }
     }
 
@@ -171,9 +200,13 @@ function tryMutate(isTv) {
         && settingsToDisable.size == 0;
 }
 
-function onFolderSelected(path) {
+function onFolderSelected(type, path) {
     elemFolderPath.value = path;
     elemFolderPath.dispatchEvent(new InputEvent('input'));
+
+    const elemFilesystemType = document.getElementById('filesystemType');
+    elemFilesystemType.value = type;
+    elemFilesystemType.dispatchEvent(new InputEvent('input'));
 }
 
 function onDeviceIdScanned(deviceId) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,8 @@
     <string name="pref_local_storage_access_name">Allow local storage access</string>
     <!-- Reason why access to local storage access is needed. /sdcard should be surrounded with <tt></tt> for displaying with a monospace font. -->
     <string name="pref_local_storage_access_desc">Needed for Syncthing to access the local storage under <tt>/sdcard</tt>.</string>
+    <!-- Title for the preference shown when access to a specific external storage folder is not granted. -->
+    <string name="pref_external_storage_access">Allow external storage access</string>
     <!-- Title for the preference shown when app hibernation is enabled. App hibernation has different names in different versions of Android, like "Manage app if unused". -->
     <string name="pref_disable_app_hibernation_name">Disable app hibernation</string>
     <!-- Reason why app hibernation needs to be disabled. -->
@@ -178,6 +180,16 @@
     <!-- Detailed message for alert shown when trying to disable "battery" optimizations on Android TV. -->
     <string name="alert_tv_inhibit_battery_opt_details">Android TV has no UI for disabling \"battery\" optimizations, but it is still required to run Syncthing in the background reliably. This must be done by running the following adb command.</string>
 
+    <!-- Title of the dialog for picking whether to use internal or external storage for a shared folder. -->
+    <string name="dialog_storage_type_title">Storage type</string>
+    <!-- Choice shown in storage type dialog for putting a shared folder on internal storage. -->
+    <string name="dialog_storage_type_internal_title">Internal storage</string>
+    <!-- Description for the storage type's internal storage option indicating that this is the most reliable option for Syncthing. -->
+    <string name="dialog_storage_type_internal_desc">Faster and has better compatibility with Syncthing.</string>
+    <!-- Choice shown in storage type dialog for putting a shared folder on external storage. -->
+    <string name="dialog_storage_type_external_title">External storage</string>
+    <!-- Description for the storage type's external storage option indicating that it is slower and less reliable. -->
+    <string name="dialog_storage_type_external_desc">Less efficient and may result in unexpected sync errors.</string>
     <!-- Button shown in the local filesystem folder picker to create a new local folder. -->
     <string name="dialog_new_folder_title">New folder</string>
     <!-- Message shown in the dialog for creating a new local filesystem folder. -->

--- a/stbridge/pidfdhack/pidfdhack.go
+++ b/stbridge/pidfdhack/pidfdhack.go
@@ -1,35 +1,4 @@
-// SPDX-FileCopyrightText: 2025-2026 Andrew Gunnerson
+// SPDX-FileCopyrightText: 2026 Andrew Gunnerson
 // SPDX-License-Identifier: GPL-3.0-only
 
-// We get killed on Android 11 and older due to seccomp blocking the pidfd_open
-// syscall. Upstream golang works around this by ignoring the SIGSYS signal for
-// that invocation (https://github.com/golang/go/pull/69543), but this does not
-// work when loaded as a shared library because go's normal signal handler is
-// not registered. To work around this, we just override checkPidfdOnce.
-
 package pidfdhack
-
-/*
-#include <android/api-level.h>
-*/
-import "C"
-import (
-	"errors"
-	_ "os"
-	_ "unsafe"
-)
-
-//go:linkname checkPidfdOnce os.checkPidfdOnce
-var checkPidfdOnce func() error
-
-var pidFdError = errors.New("Would be blocked by seccomp")
-
-func pidFdErrorFunc() error {
-	return pidFdError
-}
-
-func init() {
-	if int(C.android_get_device_api_level()) <= 30 {
-		checkPidfdOnce = pidFdErrorFunc
-	}
-}

--- a/stbridge/pidfdhack/pidfdhack_android.go
+++ b/stbridge/pidfdhack/pidfdhack_android.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2025-2026 Andrew Gunnerson
+// SPDX-License-Identifier: GPL-3.0-only
+
+// We get killed on Android 11 and older due to seccomp blocking the pidfd_open
+// syscall. Upstream golang works around this by ignoring the SIGSYS signal for
+// that invocation (https://github.com/golang/go/pull/69543), but this does not
+// work when loaded as a shared library because go's normal signal handler is
+// not registered. To work around this, we just override checkPidfdOnce.
+
+package pidfdhack
+
+/*
+#include <android/api-level.h>
+*/
+import "C"
+import (
+	"errors"
+	_ "os"
+	_ "unsafe"
+)
+
+//go:linkname checkPidfdOnce os.checkPidfdOnce
+var checkPidfdOnce func() error
+
+var pidFdError = errors.New("Would be blocked by seccomp")
+
+func pidFdErrorFunc() error {
+	return pidFdError
+}
+
+func init() {
+	if int(C.android_get_device_api_level()) <= 30 {
+		checkPidfdOnce = pidFdErrorFunc
+	}
+}

--- a/stbridge/saf.go
+++ b/stbridge/saf.go
@@ -1,0 +1,1794 @@
+// SPDX-FileCopyrightText: 2026 Andrew Gunnerson
+// SPDX-License-Identifier: GPL-3.0-only
+
+package stbridge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"maps"
+	"math"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+	"weak"
+
+	"github.com/syncthing/syncthing/lib/fs"
+	"github.com/syncthing/syncthing/lib/protocol"
+)
+
+var (
+	implLogInvocationEnable  = false
+	implLogInvocationExclude = []string{
+		"updateChildrenLocked",
+		"addChildLocked",
+		"removeChildLocked",
+		"getInfo",
+		"getChildren",
+		"Resolve",
+		"DirNames",
+		"getOrCreateChild",
+		"startWatchingLocked",
+		"stopWatchingLocked",
+		"Stat",
+	}
+	implLogStackTraceEnable  = false
+	implLogStackTraceInclude = []string{
+		"OpenFile",
+		"Rename",
+	}
+)
+
+func implShouldLog(name string) (bool, bool) {
+	logInvocation := implLogInvocationEnable && !slices.Contains(implLogInvocationExclude, name)
+	logStackTrace := implLogStackTraceEnable && slices.Contains(implLogStackTraceInclude, name)
+
+	return logInvocation, logStackTrace
+}
+
+func implLogf(name string, format string, args ...any) {
+	logInvocation, logStackTrace := implShouldLog(name)
+
+	if logInvocation {
+		msg := fmt.Sprintf(format, args...)
+		log.Printf("[IMPL] %s: %s", name, msg)
+	}
+
+	if logStackTrace {
+		for line := range strings.SplitSeq(string(debug.Stack()), "\n") {
+			if line != "" {
+				log.Printf("[IMPL] %s: Stack: %v", name, line)
+			}
+		}
+	}
+}
+
+const safPathSeparator = "/"
+
+func rawPathComponents(path string) []string {
+	result := []string{}
+
+	for component := range strings.SplitSeq(path, safPathSeparator) {
+		if component == "" || component == "." {
+			continue
+		} else {
+			result = append(result, component)
+		}
+	}
+
+	return result
+}
+
+func rawPath(path string) string {
+	return strings.Join(rawPathComponents(path), safPathSeparator)
+}
+
+func rawPathJoin(paths ...string) string {
+	return rawPath(strings.Join(paths, safPathSeparator))
+}
+
+func safePathComponents(path string) ([]string, error) {
+	result := []string{}
+
+	for component := range strings.SplitSeq(path, safPathSeparator) {
+		if component == "" || component == "." {
+			continue
+		} else if component == ".." {
+			if len(result) == 0 {
+				return nil, fmt.Errorf("unsafe path: %q", path)
+			}
+
+			result = result[:len(result)-1]
+		} else {
+			result = append(result, component)
+		}
+	}
+
+	return result, nil
+}
+
+func safePath(path string) (string, error) {
+	components, err := safePathComponents(path)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.Join(components, safPathSeparator), nil
+}
+
+func safePathSplit(path string) (string, string, error) {
+	components, err := safePathComponents(path)
+	if err != nil {
+		return "", "", err
+	}
+
+	if len(components) == 0 {
+		return "", "", nil
+	} else if len(components) == 1 {
+		return "", components[0], nil
+	} else {
+		last := len(components) - 1
+		parent := strings.Join(components[:last], safPathSeparator)
+		return parent, components[last], nil
+	}
+}
+
+func safePathJoin(paths ...string) (string, error) {
+	return safePath(strings.Join(paths, safPathSeparator))
+}
+
+func ensureSafeName(name string) error {
+	if name == ".." || strings.Contains(name, safPathSeparator) {
+		return fmt.Errorf("unsafe filename: %q", name)
+	}
+
+	return nil
+}
+
+func isAlwaysSeekable(uri string) bool {
+	url, err := url.Parse(uri)
+	if err != nil {
+		return false
+	}
+
+	return url.Scheme == "content" && url.Host == "com.android.externalstorage.documents"
+}
+
+func encodeTreeUri(treeUri string) string {
+	// See explanation in newSafFilesystem().
+	return url.QueryEscape(treeUri)
+}
+
+type SafChangeListener interface {
+	OnChange()
+}
+
+type safChangeListenerWrapper struct {
+	onChange func()
+}
+
+func (l *safChangeListenerWrapper) OnChange() {
+	l.onChange()
+}
+
+var _ SafChangeListener = (*safChangeListenerWrapper)(nil)
+
+type SafObserver interface {
+	Cancel()
+}
+
+type SafClient interface {
+	ToTreeDocumentUri(treeUri string) (string, error)
+
+	QueryTreeRootsJson() (string, error)
+
+	QueryChildDocumentsJson(documentUri string) (string, error)
+
+	QueryDocumentJson(documentUri string) (string, error)
+
+	OpenDocument(documentUri, mode string) (int, error)
+
+	CreateDocument(parentDocumentUri, mimeType, name string) (string, error)
+
+	RenameDocument(documentUri, name string) (string, error)
+
+	DeleteDocument(documentUri string) error
+
+	MoveDocument(sourceDocumentUri, sourceParentDocumentUri, targetParentDocumentUri string) (string, error)
+
+	ObserveDocument(documentUri string, changeListener SafChangeListener) (SafObserver, error)
+}
+
+// We report all SAF errors as file not found errors. DocumentsProvider
+// implementations can technically throw more Parcelable exceptions, but that is
+// not guaranteed to be possible by the SAF API.
+type notFoundWrapper struct {
+	err error
+}
+
+func (nfw *notFoundWrapper) Error() string {
+	return nfw.err.Error()
+}
+
+func (nfw *notFoundWrapper) Unwrap() error {
+	return os.ErrNotExist
+}
+
+var _ error = (*notFoundWrapper)(nil)
+
+func wrapAsNotFound(err error) error {
+	return &notFoundWrapper{err: err}
+}
+
+func queryTreeRoots(client SafClient) ([]string, error) {
+	result, err := client.QueryTreeRootsJson()
+	if err != nil {
+		return nil, wrapAsNotFound(err)
+	}
+
+	var uris []string
+
+	if err = json.Unmarshal([]byte(result), &uris); err != nil {
+		return nil, err
+	}
+
+	return uris, nil
+}
+
+func queryChildDocuments(client SafClient, documentUri string) ([]safFileInfo, error) {
+	result, err := client.QueryChildDocumentsJson(documentUri)
+	if err != nil {
+		return nil, wrapAsNotFound(err)
+	}
+
+	var children []safFileInfo
+
+	if err = json.Unmarshal([]byte(result), &children); err != nil {
+		return nil, err
+	}
+
+	return children, nil
+}
+
+func queryDocument(client SafClient, documentUri string) (safFileInfo, error) {
+	result, err := client.QueryDocumentJson(documentUri)
+	if err != nil {
+		return safFileInfo{}, wrapAsNotFound(err)
+	}
+
+	var info safFileInfo
+
+	if err = json.Unmarshal([]byte(result), &info); err != nil {
+		return safFileInfo{}, err
+	}
+
+	return info, nil
+}
+
+type safOpts struct {
+	client        SafClient
+	cacheDuration time.Duration
+}
+
+// A file or directory entry within the SAF VFS tree. This intentionally does
+// not store [safOpts] nor use [time.Time] to keep the struct size smaller.
+// [safFileInfo] is also not used because we do not want two sources of truth
+// for whether this node is a file or directory.
+//
+// The lock for multiple nodes can be held at the same time, but the lock order
+// is always from parent to child to prevent deadlocks. A node will never be
+// moved to a different part of the tree.
+//
+// We intentionally don't store a safFileInfo here because we don't want two
+// sources of truth for whether this node is a file or directory.
+type safNode struct {
+	lock           sync.Mutex
+	parent         *safNode // Immutable, no lock required.
+	uri            string   // Immutable, no lock required.
+	name           string   // Immutable, no lock required.
+	size           int64
+	mtime          int64
+	infoExpiry     int64
+	children       map[string]*safNode
+	childrenExpiry int64
+	observer       SafObserver
+	watchManager   *safWatchManager // Immutable, no lock required.
+}
+
+const (
+	safExpired = math.MinInt64
+
+	safMimeTypeDir  = "vnd.android.document/directory"
+	safMimeTypeFile = "application/octet-stream"
+)
+
+func makeChildren(isDir bool) map[string]*safNode {
+	if isDir {
+		return map[string]*safNode{}
+	} else {
+		return nil
+	}
+}
+
+func (sn *safNode) path() string {
+	components := []string{}
+	current := sn
+
+	for current.parent != nil {
+		components = append(components, current.name)
+
+		current = current.parent
+	}
+
+	slices.Reverse(components)
+
+	// The name field has already been checked by ensureSafeName().
+	return rawPathJoin(components...)
+}
+
+func (sn *safNode) cachedInfoLocked() safFileInfo {
+	return safFileInfo{
+		Uri:    sn.uri,
+		Name_:  sn.name,
+		Size_:  sn.size,
+		Mtime:  sn.mtime,
+		IsDir_: sn.children != nil,
+	}
+}
+
+// Update the children cache for this node. This takes ownership of the map.
+//
+// Specifying an actual map will convert a file node to a directory node and
+// specifying nil will convert a directory node to a file node. Every child in
+// the new map that doesn't exist in the old map with the same name will have
+// its watcher non-recursively started. Every child in the old map that doesn't
+// exist in the new map with the same name will have its watchers recursively
+// stopped.
+func (sn *safNode) updateChildrenLocked(opts *safOpts, children map[string]*safNode, expiry int64) {
+	implLogf("updateChildrenLocked", "sn=%q, children=%+v, expiry=%v", sn.uri, children, expiry)
+
+	for name, newChild := range children {
+		if newChild != sn.children[name] {
+			newChild.StartWatching(opts)
+		}
+	}
+
+	for name, oldChild := range sn.children {
+		if oldChild != children[name] {
+			oldChild.StopWatchingRecursively()
+		}
+	}
+
+	sn.children = children
+	sn.childrenExpiry = expiry
+}
+
+// Add a child to the children cache. This takes ownership of the child node.
+//
+// If this node is not a directory, [syscall.ENOTDIR] will be returned and no
+// changes will have been made aside from recursively stopping watchers on the
+// child (because this function took ownership of it). If the new child replaces
+// an existing child, the existing child will also have its watchers recursively
+// stopped.
+//
+// The new child's watcher will be non-recursively started if the child is
+// successfully added.
+func (sn *safNode) addChildLocked(opts *safOpts, name string, child *safNode) error {
+	implLogf("addChildLocked", "sn=%q, name=%q, child=%+v", sn.uri, name, child)
+
+	if sn.children == nil {
+		child.StopWatchingRecursively()
+		return fmt.Errorf("%q: %w", sn.uri, syscall.ENOTDIR)
+	}
+
+	changed := true
+
+	if oldChild, ok := sn.children[name]; ok {
+		if oldChild == child {
+			changed = false
+		} else {
+			oldChild.StopWatchingRecursively()
+		}
+	}
+	sn.children[name] = child
+
+	if changed {
+		child.StartWatching(opts)
+	}
+
+	return nil
+}
+
+// Remove a child from the children cache.
+//
+// If the child exists, all watchers in its subtree are recursively stopped.
+//
+// If notify is false, the watcher will not be notified. This is useful during
+// renames within the same directory where addChild() is about to notify the
+// watcher anyway.
+func (sn *safNode) removeChildLocked(name string) error {
+	implLogf("removeChildLocked", "sn=%q, name=%q", sn.uri, name)
+
+	if sn.children == nil {
+		return fmt.Errorf("%q: %w", sn.uri, syscall.ENOTDIR)
+	}
+
+	if child, ok := sn.children[name]; ok {
+		child.StopWatchingRecursively()
+		delete(sn.children, name)
+	}
+
+	return nil
+}
+
+// Get the current node's metadata, refreshing it if it expired. This returns a
+// copy of the internal field.
+//
+// If the URI or name changes, an error will be returned and the cached metadata
+// is left unchanged. If the file type (file vs. directory) changes, the cached
+// children will be invalidated.
+func (sn *safNode) getInfo(opts *safOpts) (*safFileInfo, error) {
+	implLogf("getInfo", "sn=%q", sn.uri)
+
+	sn.lock.Lock()
+	defer sn.lock.Unlock()
+
+	now := time.Now()
+	if !now.After(time.Unix(sn.infoExpiry, 0)) {
+		oldInfo := sn.cachedInfoLocked()
+		return &oldInfo, nil
+	}
+
+	expiry := now.Add(opts.cacheDuration)
+
+	info := safFileInfo{}
+
+	// Empty URI is the "virtual" root node when using /rest/system/browse.
+	if sn.uri == "" {
+		info.IsDir_ = true
+	} else {
+		var err error
+		info, err = queryDocument(opts.client, sn.uri)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if sn.parent == nil {
+		// This is the initial query when creating the root node.
+		if sn.uri == "" {
+			sn.uri = info.Uri
+		}
+		if sn.name == "" {
+			sn.name = info.Name_
+		}
+	}
+
+	if info.Uri != sn.uri {
+		return nil, fmt.Errorf(
+			"URI unexpectedly changed: %q -> %q: %w",
+			sn.uri, info.Uri, os.ErrInvalid,
+		)
+	} else if info.Name_ != sn.name {
+		return nil, fmt.Errorf(
+			"name unexpectedly changed: %q -> %q: %w",
+			sn.name, info.Name_, os.ErrInvalid,
+		)
+	} else if err := ensureSafeName(info.Name_); err != nil {
+		return nil, err
+	}
+
+	sn.size = info.Size_
+	sn.mtime = info.Mtime
+	sn.infoExpiry = expiry.Unix()
+
+	if info.IsDir_ != (sn.children != nil) {
+		sn.updateChildrenLocked(opts, makeChildren(info.IsDir_), safExpired)
+	}
+
+	return &info, nil
+}
+
+// Get the current node's list of children if it is a directory, refreshing the
+// list if it expired. This returns a copy of the internal field.
+//
+// If this node is not a directory and allowFiles is false, an error wrapping
+// [syscall.ENOTDIR] is returned. The cached metadata info is used to determine
+// if the node is a directory. [safNode.getInfoLocked] is never called. Because
+// SAF returns the metadata of all the children, the children will have
+// non-expired info fields, but expired (and empty/nil) children fields.
+func (sn *safNode) getChildren(opts *safOpts, allowFiles bool) (map[string]*safNode, error) {
+	implLogf("getChildren", "sn=%q, allowFiles=%v", sn.uri, allowFiles)
+
+	sn.lock.Lock()
+	defer sn.lock.Unlock()
+
+	if sn.children == nil {
+		if allowFiles {
+			return nil, nil
+		} else {
+			return nil, fmt.Errorf("%q: %w", sn.uri, syscall.ENOTDIR)
+		}
+	}
+
+	now := time.Now()
+	if !now.After(time.Unix(sn.childrenExpiry, 0)) {
+		return maps.Clone(sn.children), nil
+	}
+
+	expiry := now.Add(opts.cacheDuration)
+	children := map[string]*safNode{}
+
+	if sn.uri == "" {
+		// This is the "virtual" root node when using /rest/system/browse. We
+		// create children for each of the persisted tree URIs and they are the
+		// actual root nodes used when initializing a filesystem with them as
+		// the root URI. These nodes are attached the virtual root node in one
+		// direction only: parent->child, not child->parent.
+		treeUris, err := queryTreeRoots(opts.client)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, treeUri := range treeUris {
+			child, err := newCachedSafTreeFromUri(opts, treeUri)
+			if err != nil {
+				return nil, err
+			}
+
+			children[encodeTreeUri(treeUri)] = child
+		}
+	} else {
+		childInfos, err := queryChildDocuments(opts.client, sn.uri)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, childInfo := range childInfos {
+			if err = ensureSafeName(childInfo.Name_); err != nil {
+				return nil, err
+			}
+			if _, ok := children[childInfo.Name_]; ok {
+				return nil, fmt.Errorf(
+					"duplicate child %q in %q: %w",
+					childInfo.Name_, sn.uri, os.ErrInvalid,
+				)
+			}
+
+			// Try to avoid throwing away the whole subtree if possible.
+			child, ok := sn.children[childInfo.Name_]
+			if ok && child.uri == childInfo.Uri {
+				child.lock.Lock()
+				child.size = childInfo.Size_
+				child.mtime = childInfo.Mtime
+				child.infoExpiry = expiry.Unix()
+				if (child.children != nil) != childInfo.IsDir_ {
+					child.updateChildrenLocked(opts, makeChildren(childInfo.IsDir_), safExpired)
+				}
+				child.lock.Unlock()
+			} else {
+				child = &safNode{
+					parent:         sn,
+					uri:            childInfo.Uri,
+					name:           childInfo.Name_,
+					size:           childInfo.Size_,
+					mtime:          childInfo.Mtime,
+					infoExpiry:     expiry.Unix(),
+					children:       makeChildren(childInfo.IsDir_),
+					childrenExpiry: safExpired,
+					watchManager:   sn.watchManager,
+				}
+			}
+
+			children[childInfo.Name_] = child
+		}
+	}
+
+	sn.updateChildrenLocked(opts, children, expiry.Unix())
+
+	return children, nil
+}
+
+// Get the child node referenced by the specified relative path. ".." components
+// are permitted in the path if they don't result in escaping the current node.
+// Evaluating ".." is done lexicographically without regard for whether the
+// preceding component is a directory or not.
+//
+// This function will trigger a refresh of expired children fields for every
+// node starting from this node up to, but excluding, the child.
+func (sn *safNode) Resolve(opts *safOpts, name string) (*safNode, error) {
+	implLogf("Resolve", "sn=%q, name=%q", sn.uri, name)
+
+	components, err := safePathComponents(name)
+	if err != nil {
+		return nil, err
+	}
+
+	current := sn
+
+	for _, component := range components {
+		children, err := current.getChildren(opts, false)
+		if err != nil {
+			return nil, err
+		}
+
+		child, ok := children[component]
+		if !ok {
+			return nil, fmt.Errorf(
+				"%q not a child of %q: %w",
+				component, current.uri, os.ErrNotExist,
+			)
+		}
+
+		current = child
+	}
+
+	return current, nil
+}
+
+// Get the list of child names if this node is a directory.
+//
+// This function will trigger a refresh of expired children fields for every
+// node starting from this node up to, and including, the child.
+func (sn *safNode) DirNames(opts *safOpts, name string) ([]string, error) {
+	implLogf("DirNames", "sn=%q, name=%q", sn.uri, name)
+
+	dir, err := sn.Resolve(opts, name)
+	if err != nil {
+		return nil, err
+	}
+
+	children, err := dir.getChildren(opts, false)
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(children))
+
+	for name := range children {
+		names = append(names, name)
+	}
+
+	return names, nil
+}
+
+type creationMode int
+
+const (
+	nodeCanExist creationMode = iota
+	nodeMustExist
+	nodeMustNotExist
+)
+
+// Depending on the specified [creationMode], get the existing child and/or
+// create it if it is missing.
+//
+// If a new node is created, it will have non-expired info and children fields.
+//
+// This function will trigger a refresh of expired children fields for every
+// node starting from this node up to, but excluding, the child.
+func (sn *safNode) getOrCreateChild(
+	opts *safOpts,
+	name string,
+	isDir bool,
+	mode creationMode,
+) (*safNode, bool, error) {
+	implLogf("getOrCreateChild", "sn=%q, name=%q, isDir=%v, mode=%v", sn.uri, name, isDir, mode)
+
+	parentPath, childName, err := safePathSplit(name)
+	if err != nil {
+		return nil, false, err
+	}
+
+	parent, err := sn.Resolve(opts, parentPath)
+	if err != nil {
+		return nil, false, err
+	}
+
+	isNew := false
+
+	child, err := parent.Resolve(opts, childName)
+	if err != nil {
+		if mode == nodeMustExist || !errors.Is(err, os.ErrNotExist) {
+			return nil, false, err
+		}
+
+		var mimeType string
+		if isDir {
+			mimeType = safMimeTypeDir
+		} else {
+			mimeType = safMimeTypeFile
+		}
+
+		uri, err := opts.client.CreateDocument(parent.uri, mimeType, childName)
+		if err != nil {
+			return nil, false, wrapAsNotFound(err)
+		}
+
+		now := time.Now()
+		expiry := now.Add(opts.cacheDuration)
+
+		child = &safNode{
+			parent:         parent,
+			uri:            uri,
+			name:           childName,
+			size:           0,
+			mtime:          now.UnixMilli(), // Close enough.
+			infoExpiry:     expiry.Unix(),
+			children:       makeChildren(isDir),
+			childrenExpiry: expiry.Unix(),
+			watchManager:   sn.watchManager,
+		}
+
+		parent.lock.Lock()
+		defer parent.lock.Unlock()
+
+		if err = parent.addChildLocked(opts, childName, child); err != nil {
+			return nil, false, err
+		}
+
+		isNew = true
+	} else if mode == nodeMustNotExist {
+		return nil, false, fmt.Errorf(
+			"%q already exists in %q: %w",
+			childName, parent.uri, os.ErrExist,
+		)
+	}
+
+	return child, isNew, nil
+}
+
+// Create the specified directory. This function will fail with [os.ErrExist] if
+// the directory already exists.
+//
+// This function will trigger a refresh of expired children fields for every
+// node starting from this node up to, but excluding, the child.
+func (sn *safNode) Mkdir(opts *safOpts, name string) (*safNode, error) {
+	implLogf("Mkdir", "sn=%q, name=%q", sn.uri, name)
+
+	child, _, err := sn.getOrCreateChild(opts, name, true, nodeMustNotExist)
+	return child, err
+}
+
+// Create the specified directory along with any missing parent directories.
+// This function does not fail if the specified directory already exists.
+//
+// This function will trigger a refresh of expired children fields for every
+// node starting from this node up to, but excluding, the child.
+func (sn *safNode) MkdirAll(opts *safOpts, name string) (*safNode, bool, error) {
+	implLogf("MkdirAll", "sn=%q, name=%q", sn.uri, name)
+
+	components, err := safePathComponents(name)
+	if err != nil {
+		return nil, false, err
+	}
+
+	current := sn
+	currentIsNew := false
+
+	for _, component := range components {
+		child, isNew, err := current.getOrCreateChild(opts, component, true, nodeCanExist)
+		if err != nil {
+			return nil, false, err
+		}
+
+		current = child
+		currentIsNew = currentIsNew || isNew
+	}
+
+	return current, currentIsNew, nil
+}
+
+// Open or create the specified file. Only the [os.O_RDONLY], [os.O_WRONLY],
+// [os.O_RDWR], [os.O_CREATE], [os.O_TRUNC], and [os.O_EXCL] flags are
+// supported.
+//
+// [os.O_RDONLY] and [os.O_WRONLY] only result in read-only and write-only
+// underlying file descriptors when the SAF authority is Android's builtin
+// external storage provider. For all other SAF authorities, the underlying file
+// descriptor is opened with [os.O_RDWR] to guarantee that Android provides a
+// seekable file descriptor.
+//
+// This function will trigger a refresh of expired children fields for every
+// node starting from this node up to, but excluding, the child.
+func (sn *safNode) OpenFile(opts *safOpts, name string, flags int) (*safFile, error) {
+	implLogf("OpenFile", "sn=%q, name=%q, flags=%#x", sn.uri, name, flags)
+
+	var creationMode creationMode
+	if flags&os.O_CREATE != 0 {
+		if flags&os.O_EXCL != 0 {
+			creationMode = nodeMustNotExist
+		} else {
+			creationMode = nodeCanExist
+		}
+	} else {
+		creationMode = nodeMustExist
+	}
+
+	child, _, err := sn.getOrCreateChild(opts, name, false, creationMode)
+	if err != nil {
+		return nil, err
+	}
+
+	safMode := "rw"
+	if flags&os.O_RDWR == 0 && isAlwaysSeekable(child.uri) {
+		if flags&os.O_WRONLY != 0 {
+			safMode = "w"
+		} else {
+			safMode = "r"
+		}
+	}
+
+	// android-10.0.0_r1 is the first Android version that guaranteed that
+	// O_TRUNC is only passed when 't' is present for "w" vs "wt" [1]. However,
+	// "rw" has never truncated since the very beginning [2].
+	//
+	// [1] https://android.googlesource.com/platform/frameworks/base/+/63280e06fc64672ab36d14f852b13df2274cc328%5E!/
+	// [2] https://android.googlesource.com/platform/frameworks/base/+/9066cfe9886ac131c34d59ed0e2d287b0e3c0087%5E!/
+	if flags&os.O_TRUNC != 0 {
+		safMode += "t"
+	}
+
+	fd, err := opts.client.OpenDocument(child.uri, safMode)
+	if err != nil {
+		return nil, wrapAsNotFound(err)
+	}
+
+	return &safFile{
+		opts:     opts,
+		file:     os.NewFile(uintptr(fd), name),
+		canRead:  flags&os.O_WRONLY == 0,
+		canWrite: flags&(os.O_WRONLY|os.O_RDWR) != 0,
+		node:     child,
+	}, nil
+}
+
+// Remove the specified file. The path must exist. If the path refers to a
+// directory, then it must be empty as well.
+//
+// This function will trigger a refresh of expired children fields for every
+// node starting from this node up to, and including, the child.
+func (sn *safNode) Remove(opts *safOpts, name string) error {
+	implLogf("Remove", "sn=%q, name=%q", sn.uri, name)
+
+	child, err := sn.Resolve(opts, name)
+	if err != nil {
+		return err
+	}
+
+	// SAF only supports recursive deletes, so we need to manually check for
+	// directory emptiness.
+	children, err := child.getChildren(opts, true)
+	if err != nil {
+		return err
+	}
+
+	if len(children) > 0 {
+		return fmt.Errorf("%q: %w", child.uri, syscall.ENOTEMPTY)
+	}
+
+	return sn.RemoveAll(opts, name)
+}
+
+// Recursively delete the specified file. The path does not need to exist.
+//
+// This function will trigger a refresh of expired children fields for every
+// node starting from this node up to, but excluding, the child.
+func (sn *safNode) RemoveAll(opts *safOpts, name string) error {
+	implLogf("RemoveAll", "sn=%q, name=%q", sn.uri, name)
+
+	child, err := sn.Resolve(opts, name)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		} else {
+			return err
+		}
+	}
+
+	if child == sn {
+		return fmt.Errorf("cannot delete self: %q: %w", child.uri, os.ErrInvalid)
+	}
+
+	if err = opts.client.DeleteDocument(child.uri); err != nil {
+		return wrapAsNotFound(err)
+	}
+
+	child.parent.lock.Lock()
+	defer child.parent.lock.Unlock()
+
+	if err = child.parent.removeChildLocked(child.name); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Rename the specified path to the new path.
+//
+// The file at the old path will first be moved to the parent directory of the
+// new path while keeping its existing name. Then, it will be renamed to the
+// specified new name. During both of these steps, if a file with the same name
+// already exists in the directory, the behavior is unspecified. SAF providers
+// have no guarantees for how the move and rename operations are implemented.
+//
+// For both the old and new paths, this function will trigger a refresh of
+// expired children fields for every node starting from this node up to, but
+// excluding, the child.
+func (sn *safNode) Rename(opts *safOpts, oldname string, newname string) (*safNode, error) {
+	implLogf("Rename", "sn=%q, oldname=%q, newname=%q", sn.uri, oldname, newname)
+
+	oldParentPath, oldChildName, err := safePathSplit(oldname)
+	if err != nil {
+		return nil, err
+	} else if oldChildName == "" {
+		return nil, fmt.Errorf("cannot rename root directory: %q: %w", sn.uri, os.ErrInvalid)
+	}
+
+	newParentPath, newChildName, err := safePathSplit(newname)
+	if err != nil {
+		return nil, err
+	} else if newChildName == "" {
+		return nil, fmt.Errorf("cannot replace root directory: %q: %w", sn.uri, os.ErrInvalid)
+	}
+
+	oldParent, err := sn.Resolve(opts, oldParentPath)
+	if err != nil {
+		return nil, err
+	}
+
+	newParent := oldParent
+	if newParentPath != oldParentPath {
+		newParent, err = sn.Resolve(opts, newParentPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	child, err := oldParent.Resolve(opts, oldChildName)
+	if err != nil {
+		return nil, err
+	}
+
+	if oldParent != newParent {
+		newChildUri, err := opts.client.MoveDocument(child.uri, oldParent.uri, newParent.uri)
+		if err != nil {
+			return nil, wrapAsNotFound(err)
+		}
+
+		oldParent.lock.Lock()
+		err = oldParent.removeChildLocked(oldChildName)
+		oldParent.lock.Unlock()
+		if err != nil {
+			return nil, err
+		}
+
+		child.lock.Lock()
+		newChild := &safNode{
+			parent:         newParent,
+			uri:            newChildUri,
+			name:           child.name,
+			size:           child.size,
+			mtime:          child.mtime,
+			infoExpiry:     child.infoExpiry,
+			children:       makeChildren(child.children != nil),
+			childrenExpiry: safExpired,
+			watchManager:   sn.watchManager,
+		}
+		child.lock.Unlock()
+
+		newParent.lock.Lock()
+		err = newParent.addChildLocked(opts, oldChildName, newChild)
+		newParent.lock.Unlock()
+		if err != nil {
+			return nil, err
+		}
+
+		child = newChild
+	}
+
+	if oldChildName != newChildName {
+		newChildUri, err := opts.client.RenameDocument(child.uri, newChildName)
+		if err != nil {
+			return nil, wrapAsNotFound(err)
+		}
+
+		newParent.lock.Lock()
+		defer newParent.lock.Unlock()
+
+		if err = newParent.removeChildLocked(oldChildName); err != nil {
+			return nil, err
+		}
+
+		child.lock.Lock()
+		newChild := &safNode{
+			parent:         newParent,
+			uri:            newChildUri,
+			name:           newChildName,
+			size:           child.size,
+			mtime:          child.mtime,
+			infoExpiry:     child.infoExpiry,
+			children:       makeChildren(child.children != nil),
+			childrenExpiry: safExpired,
+			watchManager:   sn.watchManager,
+		}
+		child.lock.Unlock()
+
+		if err = newParent.addChildLocked(opts, newChildName, newChild); err != nil {
+			return nil, err
+		}
+
+		child = newChild
+	}
+
+	return child, nil
+}
+
+// Get the metadata for the specified file. This returns a copy of the internal
+// info field.
+//
+// This function will trigger a refresh of an expired info field of the child
+// node and also any expired children fields for every node starting from this
+// node up to, but excluding, the child.
+func (sn *safNode) Stat(opts *safOpts, name string) (*safFileInfo, error) {
+	implLogf("Stat", "sn=%q, name=%q", sn.uri, name)
+
+	child, err := sn.Resolve(opts, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return child.getInfo(opts)
+}
+
+func (sn *safNode) startWatchingLocked(opts *safOpts) {
+	implLogf("startWatchingLocked", "sn=%q", sn.uri)
+
+	if sn.observer != nil || !sn.watchManager.ShouldWatch() || sn.uri == "" || sn.children == nil {
+		return
+	}
+
+	listener := safChangeListenerWrapper{
+		onChange: func() {
+			sn.lock.Lock()
+			sn.childrenExpiry = safExpired
+			sn.lock.Unlock()
+
+			sn.watchManager.OnChange(sn.path())
+		},
+	}
+
+	observer, err := opts.client.ObserveDocument(sn.uri, &listener)
+	if err != nil {
+		log.Printf("failed to start watcher: %q: %v", sn.uri, err)
+	} else {
+		sn.observer = observer
+		sn.watchManager.IncCount()
+	}
+}
+
+func (sn *safNode) stopWatchingLocked() {
+	implLogf("stopWatchingLocked", "sn=%q", sn.uri)
+
+	if sn.observer != nil {
+		sn.observer.Cancel()
+		sn.observer = nil
+		sn.watchManager.DecCount()
+	}
+}
+
+func (sn *safNode) StartWatching(opts *safOpts) {
+	sn.lock.Lock()
+	defer sn.lock.Unlock()
+
+	sn.startWatchingLocked(opts)
+}
+
+func (sn *safNode) StopWatching() {
+	sn.lock.Lock()
+	defer sn.lock.Unlock()
+
+	sn.stopWatchingLocked()
+}
+
+func (sn *safNode) startWatchingRecursivelyLocked(opts *safOpts) {
+	sn.startWatchingLocked(opts)
+
+	for _, child := range sn.children {
+		child.lock.Lock()
+		child.startWatchingRecursivelyLocked(opts)
+		child.lock.Unlock()
+	}
+}
+
+func (sn *safNode) stopWatchingRecursivelyLocked() {
+	sn.stopWatchingLocked()
+
+	for _, child := range sn.children {
+		child.lock.Lock()
+		child.stopWatchingRecursivelyLocked()
+		child.lock.Unlock()
+	}
+}
+
+func (sn *safNode) StartWatchingRecursively(opts *safOpts) {
+	sn.lock.Lock()
+	defer sn.lock.Unlock()
+
+	sn.startWatchingRecursivelyLocked(opts)
+}
+
+func (sn *safNode) StopWatchingRecursively() {
+	sn.lock.Lock()
+	defer sn.lock.Unlock()
+
+	sn.stopWatchingRecursivelyLocked()
+}
+
+func (sn *safNode) glob(
+	opts *safOpts,
+	currentPath string,
+	patternComponents,
+	results []string,
+) ([]string, error) {
+	if len(patternComponents) == 0 {
+		if len(currentPath) > 0 {
+			results = append(results, currentPath)
+		}
+
+		return results, nil
+	}
+
+	children, err := sn.getChildren(opts, true)
+	if err != nil {
+		// Filesystem errors are ignored.
+		return results, nil
+	}
+
+	for name, child := range children {
+		matches, err := filepath.Match(patternComponents[0], name)
+		if err != nil {
+			return results, err
+		}
+
+		if matches {
+			newResults, err := child.glob(
+				opts,
+				rawPathJoin(currentPath, name),
+				patternComponents[1:],
+				results,
+			)
+			results = newResults
+			if err != nil {
+				return results, err
+			}
+		}
+	}
+
+	return results, nil
+}
+
+// Return all paths that match the specified pattern. Like [filepath.Glob],
+// filesystem errors are ignored. Only errors related to the input path or
+// pattern being invalid will be returned.
+//
+// All returned paths are relative to this current node, not the root node.
+//
+// This function will trigger a refresh of expired children fields for every
+// node matching components in the pattern up to, but excluding, the child.
+func (sn *safNode) Glob(opts *safOpts, pattern string) ([]string, error) {
+	implLogf("Glob", "sn=%q, pattern=%q", sn.uri, pattern)
+
+	// Syncthing's default BasicFilesystem just uses filepath.Glob(), which does
+	// not support recursive globs (**). We can match one component at a time.
+	components, err := safePathComponents(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	return sn.glob(opts, "", components, []string{})
+}
+
+// Create a new root node from a SAF URI.
+//
+// The info and children fields will be immediately refreshed.
+func newSafRootFromUri(opts *safOpts, uri string) (*safNode, error) {
+	implLogf("newSafRootFromUri", "uri=%q", uri)
+
+	if uri != "" {
+		var err error
+		uri, err = opts.client.ToTreeDocumentUri(uri)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	node := &safNode{
+		uri:            uri,
+		infoExpiry:     safExpired,
+		childrenExpiry: safExpired,
+		watchManager:   &safWatchManager{},
+	}
+
+	if _, err := node.getInfo(opts); err != nil {
+		return nil, err
+	} else if _, err := node.getChildren(opts, true); err != nil {
+		return nil, err
+	}
+
+	return node, nil
+}
+
+type safTreeCacheKey struct {
+	opts safOpts
+	uri  string
+}
+
+var safTreeCache sync.Map // map[safTreeCacheKey]weak.Pointer[safNode]
+
+// Using the approach from https://go.dev/blog/cleanups-and-weak. Multiple SAF
+// nodes may be created (and then discarded) when racing during the first
+// multithreaded uncached access. However, this is better than just locking a
+// regular map so that slow node construction for one URI does not block
+// construction of a node for a different URI.
+func newCachedSafTreeFromUri(opts *safOpts, uri string) (*safNode, error) {
+	var key = safTreeCacheKey{opts: *opts, uri: uri}
+	var node *safNode
+
+	for {
+		value, ok := safTreeCache.Load(key)
+		if !ok {
+			if node == nil {
+				var err error
+				node, err = newSafRootFromUri(opts, uri)
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			wp := weak.Make(node)
+			var loaded bool
+			value, loaded = safTreeCache.LoadOrStore(key, wp)
+			if !loaded {
+				runtime.AddCleanup(node, func(key safTreeCacheKey) {
+					safTreeCache.CompareAndDelete(key, wp)
+				}, key)
+
+				return node, nil
+			}
+		}
+
+		if mf := value.(weak.Pointer[safNode]).Value(); mf != nil {
+			return mf, nil
+		}
+
+		safTreeCache.CompareAndDelete(key, value)
+	}
+}
+
+type safWatchManager struct {
+	lock   sync.Mutex
+	ctx    context.Context
+	ignore fs.Matcher
+	out    chan fs.Event
+	count  atomic.Int64
+}
+
+func (swm *safWatchManager) ShouldWatch() bool {
+	swm.lock.Lock()
+	defer swm.lock.Unlock()
+
+	return swm.ctx != nil
+}
+
+func (swm *safWatchManager) Start(
+	opts *safOpts,
+	root *safNode,
+	ctx context.Context,
+	ignore fs.Matcher,
+	out chan fs.Event,
+) error {
+	swm.lock.Lock()
+	if swm.ctx != nil {
+		swm.lock.Unlock()
+		return errors.New("watcher already started")
+	}
+	swm.ctx = ctx
+	swm.ignore = ignore
+	swm.out = out
+	swm.lock.Unlock()
+
+	root.StartWatchingRecursively(opts)
+
+	return nil
+}
+
+func (swm *safWatchManager) Stop(root *safNode) error {
+	swm.lock.Lock()
+	if swm.ctx == nil {
+		swm.lock.Unlock()
+		return errors.New("watcher already stopped")
+	}
+	swm.ctx = nil
+	swm.ignore = nil
+	swm.out = nil
+	swm.lock.Unlock()
+
+	root.StopWatchingRecursively()
+
+	return nil
+}
+
+func (swm *safWatchManager) OnChange(path string) {
+	implLogf("OnChange", "path=%q", path)
+
+	swm.lock.Lock()
+	ctx := swm.ctx
+	ignore := swm.ignore
+	out := swm.out
+	swm.lock.Unlock()
+
+	if ignore.Match(path).IsIgnored() {
+		return
+	}
+
+	// It's impossible to have anything more granular than this with SAF. At
+	// least FileSystemProvider's inotify event mask in DirectoryObserver is
+	// relatively sane, so we shouldn't get frequent unwanted events.
+	select {
+	case out <- fs.Event{
+		Name: path,
+		Type: fs.NonRemove,
+	}:
+	// To avoid hanging on cancel due to unbuffered channel.
+	case <-ctx.Done():
+	}
+}
+
+func (swm *safWatchManager) IncCount() {
+	count := swm.count.Add(1)
+	implLogf("IncCount", "newCount=%v", count)
+}
+
+func (swm *safWatchManager) DecCount() {
+	count := swm.count.Add(-1)
+	implLogf("DecCount", "newCount=%v", count)
+}
+
+const filesystemTypeSaf fs.FilesystemType = "saf"
+
+type safFileInfo struct {
+	Uri    string `json:"uri"`
+	Name_  string `json:"name"`
+	Size_  int64  `json:"size"`
+	Mtime  int64  `json:"mtime"`
+	IsDir_ bool   `json:"is_dir"`
+}
+
+var _ fs.FileInfo = (*safFileInfo)(nil)
+
+func (sfi *safFileInfo) Name() string {
+	return sfi.Name_
+}
+
+func (sfi *safFileInfo) Mode() fs.FileMode {
+	if sfi.IsDir_ {
+		return fs.FileMode(os.ModeDir | 0o750)
+	} else {
+		return fs.FileMode(0o640)
+	}
+}
+
+func (sfi *safFileInfo) Size() int64 {
+	return sfi.Size_
+}
+
+func (sfi *safFileInfo) ModTime() time.Time {
+	return time.UnixMilli(sfi.Mtime)
+}
+
+func (sfi *safFileInfo) IsDir() bool {
+	return sfi.IsDir_
+}
+
+func (sfi *safFileInfo) Sys() interface{} {
+	return nil
+}
+
+func (sfi *safFileInfo) IsRegular() bool {
+	return !sfi.IsDir_
+}
+
+func (sfi *safFileInfo) IsSymlink() bool {
+	// SAF is incapable of representing anything besides regular files and directories.
+	return false
+}
+
+func (sfi *safFileInfo) Owner() int {
+	// SAF has no concept of ownership.
+	return -1
+}
+
+func (sfi *safFileInfo) Group() int {
+	// SAF has no concept of ownership.
+	return -1
+}
+
+// An opened SAF file descriptor.
+type safFile struct {
+	opts     *safOpts
+	file     *os.File
+	canRead  bool
+	canWrite bool
+	node     *safNode
+}
+
+var _ fs.File = (*safFile)(nil)
+
+func (sf *safFile) Close() error {
+	return sf.file.Close()
+}
+
+func (sf *safFile) Read(p []byte) (int, error) {
+	if !sf.canRead {
+		return 0, os.ErrInvalid
+	}
+
+	return sf.file.Read(p)
+}
+
+func (sf *safFile) ReadAt(p []byte, off int64) (int, error) {
+	if !sf.canRead {
+		return 0, os.ErrInvalid
+	}
+
+	return sf.file.ReadAt(p, off)
+}
+
+func (sf *safFile) Seek(offset int64, whence int) (int64, error) {
+	return sf.file.Seek(offset, whence)
+}
+
+func (sf *safFile) Write(p []byte) (int, error) {
+	if !sf.canWrite {
+		return 0, os.ErrInvalid
+	}
+
+	return sf.file.Write(p)
+}
+
+func (sf *safFile) WriteAt(p []byte, off int64) (int, error) {
+	if !sf.canWrite {
+		return 0, os.ErrInvalid
+	}
+
+	return sf.file.WriteAt(p, off)
+}
+
+func (sf *safFile) Name() string {
+	// This is the path that was passed to safFilesystem.Open(). It is purely
+	// informational.
+	return sf.file.Name()
+}
+
+func (sf *safFile) Truncate(size int64) error {
+	if !sf.canWrite {
+		return os.ErrInvalid
+	}
+
+	// This will only ever work for AOSP's FileSystemProvider. Any other SAF
+	// provider that provides a seekable file descriptor is going to be using
+	// StorageManager.openProxyFileDescriptor(), which does not support
+	// ftruncate().
+	return sf.file.Truncate(size)
+}
+
+func (sf *safFile) Stat() (fs.FileInfo, error) {
+	return sf.node.Stat(sf.opts, "")
+}
+
+func (sf *safFile) Sync() error {
+	return sf.file.Sync()
+}
+
+type safFilesystem struct {
+	opts     *safOpts
+	treeUri  string
+	rootPath string
+	root     *safNode
+	options  []fs.Option
+}
+
+var _ fs.Filesystem = (*safFilesystem)(nil)
+
+var (
+	errPermissionsNotSupported  = errors.New("SAF does not support file permissions")
+	errOwnershipNotSupported    = errors.New("SAF does not support file ownership")
+	errTimestampSetNotSupported = errors.New("SAF does not support changing timestamps")
+	errSymlinksNotSupported     = errors.New("SAF does not support symlinks")
+	errWalkNotImplemented       = errors.New("SAF walk not implemented")
+	errUsageNotSupported        = errors.New("SAF does not support usage reporting")
+)
+
+func (sfs *safFilesystem) Chmod(name string, mode fs.FileMode) error {
+	return errPermissionsNotSupported
+}
+
+func (sfs *safFilesystem) Lchown(name string, uid, gid string) error {
+	return errOwnershipNotSupported
+}
+
+func (sfs *safFilesystem) Chtimes(name string, atime time.Time, mtime time.Time) error {
+	return errTimestampSetNotSupported
+}
+
+func (sfs *safFilesystem) Create(name string) (fs.File, error) {
+	return sfs.OpenFile(name, os.O_CREATE|os.O_TRUNC, 0)
+}
+
+func (sfs *safFilesystem) CreateSymlink(target, name string) error {
+	return errSymlinksNotSupported
+}
+
+func (sfs *safFilesystem) DirNames(name string) ([]string, error) {
+	return sfs.root.DirNames(sfs.opts, name)
+}
+
+func (sfs *safFilesystem) Lstat(name string) (fs.FileInfo, error) {
+	// SAF does not support symlinks.
+	return sfs.Stat(name)
+}
+
+func (sfs *safFilesystem) Mkdir(name string, perm fs.FileMode) error {
+	_, err := sfs.root.Mkdir(sfs.opts, name)
+	return err
+}
+
+func (sfs *safFilesystem) MkdirAll(name string, perm fs.FileMode) error {
+	_, _, err := sfs.root.MkdirAll(sfs.opts, name)
+	return err
+}
+
+func (sfs *safFilesystem) Open(name string) (fs.File, error) {
+	return sfs.OpenFile(name, os.O_RDONLY, 0)
+}
+
+func (sfs *safFilesystem) OpenFile(name string, flags int, mode fs.FileMode) (fs.File, error) {
+	return sfs.root.OpenFile(sfs.opts, name, flags)
+}
+
+func (sfs *safFilesystem) ReadSymlink(name string) (string, error) {
+	return "", errSymlinksNotSupported
+}
+
+func (sfs *safFilesystem) Remove(name string) error {
+	return sfs.root.Remove(sfs.opts, name)
+}
+
+func (sfs *safFilesystem) RemoveAll(name string) error {
+	return sfs.root.RemoveAll(sfs.opts, name)
+}
+
+func (sfs *safFilesystem) Rename(oldname, newname string) error {
+	_, err := sfs.root.Rename(sfs.opts, oldname, newname)
+	return err
+}
+
+func (sfs *safFilesystem) Stat(name string) (fs.FileInfo, error) {
+	return sfs.root.Stat(sfs.opts, name)
+}
+
+func (sfs *safFilesystem) Walk(name string, walkFn fs.WalkFunc) error {
+	// Syncthing handles walking in WalkFilesystem. BasicFilesystem doesn't implement this either.
+	return errWalkNotImplemented
+}
+
+func (sfs *safFilesystem) Watch(
+	path string,
+	ignore fs.Matcher,
+	ctx context.Context,
+	ignorePerms bool,
+) (<-chan fs.Event, <-chan error, error) {
+	outChan := make(chan fs.Event)
+	// There are no errors we can ever report.
+	errChan := make(chan error)
+
+	// This is only ever called for the root path: "." in monitorWatch() in
+	// lib/model/folder.go, so we don't bother complicating the code with
+	// supporting multiple watchers or watching subtrees.
+	if path != "." {
+		return nil, nil, errors.New("this watch implementation only supports the root")
+	}
+
+	if err := sfs.root.watchManager.Start(sfs.opts, sfs.root, ctx, ignore, outChan); err != nil {
+		return nil, nil, err
+	}
+
+	go func() {
+		<-ctx.Done()
+
+		if err := sfs.root.watchManager.Stop(sfs.root); err != nil {
+			log.Print(err)
+		}
+	}()
+
+	return outChan, errChan, nil
+}
+
+func (sfs *safFilesystem) Hide(name string) error {
+	// BasicFilesystem checks that the file exists, but makes it a no-op.
+	_, err := sfs.root.Resolve(sfs.opts, name)
+	return err
+}
+
+func (sfs *safFilesystem) Unhide(name string) error {
+	// BasicFilesystem checks that the file exists, but makes it a no-op.
+	_, err := sfs.root.Resolve(sfs.opts, name)
+	return err
+}
+
+func (sfs *safFilesystem) Glob(pattern string) ([]string, error) {
+	return sfs.root.Glob(sfs.opts, pattern)
+}
+
+func (sfs *safFilesystem) Roots() ([]string, error) {
+	if sfs.treeUri == "" {
+		return sfs.root.DirNames(sfs.opts, "")
+	}
+
+	return []string{encodeTreeUri(sfs.treeUri)}, nil
+}
+
+func (sfs *safFilesystem) Usage(name string) (fs.Usage, error) {
+	// We can't make use of COLUMN_CAPACITY_BYTES and COLUMN_AVAILABLE_BYTES
+	// from the DocumentsProvider's queryRoots() because we don't have
+	// permissions to SAF roots URIs.
+	return fs.Usage{}, errUsageNotSupported
+}
+
+func (sfs *safFilesystem) Type() fs.FilesystemType {
+	return filesystemTypeSaf
+}
+
+func (sfs *safFilesystem) URI() string {
+	// Used in:
+	// - lib/config/folderconfiguration.go : ModTimeWindow()
+	//   - Assumes that the filesystem is local on Android and passes the URI
+	//     value directly to disk.Usage(). This is impossible to work around,
+	//     but is non-fatal, so we'll just ignore it.
+	// - lib/ignore/ignore.go : loadParseIncludeFile()
+	//   - Skipped for custom filesystems.
+	// - lib/model/model.go : warnAboutOverwritingProtectedFiles()
+	//   - Skipped for custom filesystems.
+	// - lib/osutil/osutil.go : RenameOrCopy()
+	//   - Used for determining if Rename() can be used across filesystems.
+	//     Using the URL-encoded SAF tree URI is fine for this.
+	// - lib/versioner/external.go : Archive()
+	//   - Used for expanding %FOLDER_PATH%. There's not much we can do here.
+	// - lib/versioner/util.go : Archive()
+	//   - Used for creating a new fs.Filesystem instance for the .stversions
+	//     directory. Uses filepath.Join() to combine the URI with .stversions.
+
+	// rootPath is always constructed with a safe path.
+	return rawPathJoin(encodeTreeUri(sfs.treeUri), sfs.rootPath)
+}
+
+func (sfs *safFilesystem) Options() []fs.Option {
+	return sfs.options
+}
+
+func (sfs *safFilesystem) SameFile(fi1, fi2 fs.FileInfo) bool {
+	info1, ok := fi1.(*safFileInfo)
+	if !ok {
+		return false
+	}
+
+	info2, ok := fi2.(*safFileInfo)
+	if !ok {
+		return false
+	}
+
+	return info1.Uri == info2.Uri
+}
+
+func (sfs *safFilesystem) PlatformData(
+	name string,
+	withOwnership,
+	withXattrs bool,
+	xattrFilter fs.XattrFilter,
+) (protocol.PlatformData, error) {
+	return protocol.PlatformData{}, nil
+}
+
+func (sfs *safFilesystem) GetXattr(
+	name string,
+	xattrFilter fs.XattrFilter,
+) ([]protocol.Xattr, error) {
+	return nil, fs.ErrXattrsNotSupported
+}
+
+func (sfs *safFilesystem) SetXattr(
+	path string,
+	xattrs []protocol.Xattr,
+	xattrFilter fs.XattrFilter,
+) error {
+	return fs.ErrXattrsNotSupported
+}
+
+var globalSafClient SafClient
+
+func SetSafClient(client SafClient) {
+	globalSafClient = client
+}
+
+func newSafFilesystem(encodedUri string, opts ...fs.Option) (fs.Filesystem, error) {
+	client := globalSafClient
+	if client == nil {
+		return nil, errors.New("no SafClient has been set")
+	}
+
+	safOpts := &safOpts{
+		client:        client,
+		cacheDuration: 300 * time.Second,
+	}
+
+	// The URI is <URL-encoded SAF tree URI>[/<relative path>]. This format is
+	// picked because Syncthing expects the URI to be usable with filepath
+	// functions. We can't ever let the actual SAF tree URI get broken up since
+	// it is just an opaque string.
+	treeUriEncoded, rootPath, hasPath := strings.Cut(encodedUri, safPathSeparator)
+
+	treeUri, err := url.QueryUnescape(treeUriEncoded)
+	if err != nil {
+		return nil, err
+	}
+
+	root, err := newCachedSafTreeFromUri(safOpts, treeUri)
+	if err != nil {
+		return nil, err
+	}
+
+	// If we're looking at a subpath, we unfortunately need to create it if it's
+	// missing. We can't construct SAF URIs out of thin air since they are
+	// opaque.
+	if hasPath {
+		rootPath, err = safePath(rootPath)
+		if err != nil {
+			return nil, err
+		}
+
+		child, err := root.Resolve(safOpts, rootPath)
+		if err != nil && errors.Is(err, os.ErrNotExist) {
+			child, _, err = root.MkdirAll(safOpts, rootPath)
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		child.parent = nil
+		root = child
+	}
+
+	return &safFilesystem{
+		opts:     safOpts,
+		treeUri:  treeUri,
+		rootPath: rootPath,
+		root:     root,
+		options:  opts,
+	}, nil
+}
+
+func init() {
+	fs.RegisterFilesystemType(filesystemTypeSaf, newSafFilesystem)
+}

--- a/stbridge/saf_test.go
+++ b/stbridge/saf_test.go
@@ -1,0 +1,1041 @@
+// SPDX-FileCopyrightText: 2026 Andrew Gunnerson
+// SPDX-License-Identifier: GPL-3.0-only
+
+package stbridge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/syncthing/syncthing/lib/fs"
+	"github.com/syncthing/syncthing/lib/ignore/ignoreresult"
+)
+
+func TestSafePath(t *testing.T) {
+	for _, i := range []struct {
+		path     string
+		expected string
+		unsafe   bool
+	}{
+		{path: "", expected: ""},
+		{path: ".", expected: ""},
+		{path: "/", expected: ""},
+		{path: "a", expected: "a"},
+		{path: "/a", expected: "a"},
+		{path: ".////./.", expected: ""},
+		{path: "..", unsafe: true},
+		{path: "../..", unsafe: true},
+		{path: "a/../b", expected: "b"},
+		{path: "a/../..", unsafe: true},
+	} {
+		result, err := safePath(i.path)
+		if i.unsafe {
+			if err == nil {
+				t.Errorf("unsafe path was accepted: %q", i.path)
+			}
+		} else {
+			if err != nil {
+				t.Error(err)
+			} else if result != i.expected {
+				t.Errorf("invalid safe path: %q != %q", result, i.expected)
+			}
+		}
+	}
+}
+
+func TestSafePathSplit(t *testing.T) {
+	for _, i := range []struct {
+		path   string
+		parent string
+		base   string
+		unsafe bool
+	}{
+		{path: "", parent: "", base: ""},
+		{path: ".", parent: "", base: ""},
+		{path: "/", parent: "", base: ""},
+		{path: "..", unsafe: true},
+		{path: "/a", parent: "", base: "a"},
+		{path: "a/", parent: "", base: "a"},
+		{path: "a/b", parent: "a", base: "b"},
+		{path: "a/////b/////c", parent: "a/b", base: "c"},
+	} {
+		parent, base, err := safePathSplit(i.path)
+		if i.unsafe {
+			if err == nil {
+				t.Errorf("unsafe path was accepted: %q", i.path)
+			}
+		} else {
+			if err != nil {
+				t.Error(err)
+			} else if parent != i.parent {
+				t.Errorf("%q: invalid parent: %q != %q", i.path, parent, i.parent)
+			} else if base != i.base {
+				t.Errorf("%q: invalid base: %q != %q", i.path, base, i.base)
+			}
+		}
+	}
+}
+
+func TestSafePathJoin(t *testing.T) {
+	for _, i := range []struct {
+		paths    []string
+		expected string
+		unsafe   bool
+	}{
+		{paths: []string{}, expected: ""},
+		{paths: []string{".", "", "/", "///"}, expected: ""},
+		{paths: []string{"/a"}, expected: "a"},
+		{paths: []string{"/a//", "b///../..", "./c"}, expected: "c"},
+		{paths: []string{"a", "b", "../../c/../.."}, unsafe: true},
+	} {
+		result, err := safePathJoin(i.paths...)
+		if i.unsafe {
+			if err == nil {
+				t.Errorf("unsafe path was accepted: %+v", i.paths)
+			}
+		} else {
+			if err != nil {
+				t.Error(err)
+			} else if result != i.expected {
+				t.Errorf("%+v: invalid joined path: %q != %q", i.paths, result, i.expected)
+			}
+		}
+	}
+}
+
+func TestIsAlwaysSeekable(t *testing.T) {
+	if !isAlwaysSeekable("content://com.android.externalstorage.documents/tree/primary%3Atest") {
+		t.Errorf("external storage provider not detected")
+	}
+	if isAlwaysSeekable("content://com.chiller3.rsaf.documents/tree/remote%3Atest") {
+		t.Errorf("external storage provider incorrectly detected")
+	}
+}
+
+type mockSafClient struct {
+	queryTreeRootsJson      func() (string, error)
+	queryChildDocumentsJson func(documentUri string) (string, error)
+	queryDocumentJson       func(documentUri string) (string, error)
+	openDocument            func(documentUri, mode string) (int, error)
+	createDocument          func(parentDocumentUri, mimeType, name string) (string, error)
+	renameDocument          func(documentUri, name string) (string, error)
+	deleteDocument          func(documentUri string) error
+	moveDocument            func(sourceDocumentUri, sourceParentDocumentUri, targetParentDocumentUri string) (string, error)
+	observeDocument         func(documentUri string, changeListener SafChangeListener) (SafObserver, error)
+}
+
+func (msc *mockSafClient) ToTreeDocumentUri(treeUri string) (string, error) {
+	return treeUri, nil
+}
+
+func (msc *mockSafClient) QueryTreeRootsJson() (string, error) {
+	return msc.queryTreeRootsJson()
+}
+
+func (msc *mockSafClient) QueryChildDocumentsJson(documentUri string) (string, error) {
+	return msc.queryChildDocumentsJson(documentUri)
+}
+
+func (msc *mockSafClient) QueryDocumentJson(documentUri string) (string, error) {
+	return msc.queryDocumentJson(documentUri)
+}
+
+func (msc *mockSafClient) OpenDocument(documentUri, mode string) (int, error) {
+	return msc.openDocument(documentUri, mode)
+}
+
+func (msc *mockSafClient) CreateDocument(parentDocumentUri, mimeType, name string) (string, error) {
+	return msc.createDocument(parentDocumentUri, mimeType, name)
+}
+
+func (msc *mockSafClient) RenameDocument(documentUri, name string) (string, error) {
+	return msc.renameDocument(documentUri, name)
+}
+
+func (msc *mockSafClient) DeleteDocument(documentUri string) error {
+	return msc.deleteDocument(documentUri)
+}
+
+func (msc *mockSafClient) MoveDocument(sourceDocumentUri, sourceParentDocumentUri, targetParentDocumentUri string) (string, error) {
+	return msc.moveDocument(sourceDocumentUri, sourceParentDocumentUri, targetParentDocumentUri)
+}
+
+func (msc *mockSafClient) ObserveDocument(documentUri string, changeListener SafChangeListener) (SafObserver, error) {
+	return msc.observeDocument(documentUri, changeListener)
+}
+
+var _ SafClient = (*mockSafClient)(nil)
+
+type mockMatcher struct{}
+
+func (m *mockMatcher) Match(name string) ignoreresult.R {
+	return ignoreresult.NotIgnored
+}
+
+var _ fs.Matcher = (*mockMatcher)(nil)
+
+func newTestClient() (*mockSafClient, *safOpts) {
+	client := &mockSafClient{}
+	opts := &safOpts{
+		client:        client,
+		cacheDuration: 1 * time.Hour,
+	}
+
+	return client, opts
+}
+
+var safNotExpired = time.Now().Add(1 * time.Hour).Unix()
+
+func treeRootsJson(uris ...string) string {
+	bytes, err := json.Marshal(uris)
+	if err != nil {
+		log.Fatalf("failed to encode tree URIs as JSON: %v", err)
+	}
+
+	return string(bytes)
+}
+
+func fileInfoJson(info *safFileInfo) string {
+	bytes, err := json.Marshal(info)
+	if err != nil {
+		log.Fatalf("failed to encode info as JSON: %v", err)
+	}
+
+	return string(bytes)
+}
+
+func fileInfoListJson(infos ...*safFileInfo) string {
+	bytes, err := json.Marshal(infos)
+	if err != nil {
+		log.Fatalf("failed to encode info list as JSON: %v", err)
+	}
+
+	return string(bytes)
+}
+
+func TestGetInfo(t *testing.T) {
+	newInfo := safFileInfo{
+		Uri:    "uri://0",
+		Name_:  "0",
+		Size_:  1,
+		Mtime:  1,
+		IsDir_: false,
+	}
+	node := &safNode{
+		uri:            "uri://0",
+		name:           "0",
+		size:           0,
+		mtime:          0,
+		infoExpiry:     safExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safNotExpired,
+		watchManager:   &safWatchManager{},
+	}
+
+	calls := 0
+
+	client, opts := newTestClient()
+	client.queryDocumentJson = func(documentUri string) (string, error) {
+		calls++
+		return fileInfoJson(&newInfo), nil
+	}
+
+	info, err := node.getInfo(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Errorf("queryDocumentJson was not called when expired")
+	}
+	if *info != newInfo {
+		t.Errorf("info does not match: %+v != %+v", info, newInfo)
+	}
+	if node.children != nil || node.childrenExpiry != safExpired {
+		t.Errorf("children did not get invalidated: %+v: %v", node.children, node.childrenExpiry)
+	}
+
+	info, err = node.getInfo(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Errorf("queryDocumentJson was called when not expired")
+	}
+	if *info != newInfo {
+		t.Errorf("info does not match: %+v != %+v", info, newInfo)
+	}
+}
+
+func TestGetChildren(t *testing.T) {
+	node := &safNode{
+		uri:            "uri://0",
+		name:           "0",
+		size:           0,
+		mtime:          0,
+		infoExpiry:     safExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safExpired,
+		watchManager:   &safWatchManager{},
+	}
+	childFileInfo := safFileInfo{
+		Uri:    "uri://1",
+		Name_:  "1",
+		Size_:  1,
+		Mtime:  1,
+		IsDir_: false,
+	}
+	childDirInfo := safFileInfo{
+		Uri:    "uri://2",
+		Name_:  "2",
+		Size_:  2,
+		Mtime:  2,
+		IsDir_: true,
+	}
+
+	calls := 0
+
+	client, opts := newTestClient()
+	client.queryChildDocumentsJson = func(documentUri string) (string, error) {
+		calls++
+		return fileInfoListJson(&childFileInfo, &childDirInfo), nil
+	}
+
+	children, err := node.getChildren(opts, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Errorf("queryChildDocumentsJson was not called when expired")
+	}
+	if len(children) != 2 {
+		t.Errorf("invalid number of children")
+	}
+	for _, expectedInfo := range []*safFileInfo{&childFileInfo, &childDirInfo} {
+		actualNode := children[expectedInfo.Name_]
+		actualInfo := actualNode.cachedInfoLocked()
+
+		if actualInfo != *expectedInfo {
+			t.Errorf("child info does not match: %+v != %+v", actualInfo, expectedInfo)
+		}
+	}
+	if node.childrenExpiry == safExpired {
+		t.Errorf("children field is still expired")
+	}
+
+	oldChildren := children
+
+	children, err = node.getChildren(opts, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Errorf("queryChildDocumentsJson was called when not expired")
+	}
+	if !maps.Equal(children, oldChildren) {
+		t.Errorf("children changed: %+v != %+v", children, oldChildren)
+	}
+}
+
+func TestGetRoots(t *testing.T) {
+	node := &safNode{
+		uri:            "",
+		infoExpiry:     safExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safExpired,
+		watchManager:   &safWatchManager{},
+	}
+	treeInfo1 := safFileInfo{
+		Uri:    "uri://1",
+		IsDir_: true,
+	}
+	treeInfo2 := safFileInfo{
+		Uri:    "uri://2",
+		IsDir_: true,
+	}
+
+	client, opts := newTestClient()
+	client.queryTreeRootsJson = func() (string, error) {
+		return treeRootsJson("uri://1", "uri://2"), nil
+	}
+	client.queryDocumentJson = func(documentUri string) (string, error) {
+		return fileInfoJson(&safFileInfo{
+			Uri:    documentUri,
+			IsDir_: true,
+		}), nil
+	}
+	client.queryChildDocumentsJson = func(documentUri string) (string, error) {
+		if documentUri != "uri://1" && documentUri != "uri://2" {
+			t.Errorf("querying children for invalid URI: %q", documentUri)
+		}
+
+		return fileInfoListJson(), nil
+	}
+
+	children, err := node.getChildren(opts, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(children) != 2 {
+		t.Errorf("invalid number of children")
+	}
+	for _, expectedInfo := range []*safFileInfo{&treeInfo1, &treeInfo2} {
+		actualNode := children[encodeTreeUri(expectedInfo.Uri)]
+		actualInfo := actualNode.cachedInfoLocked()
+
+		if actualInfo != *expectedInfo {
+			t.Errorf("child info does not match: %+v != %+v", actualInfo, expectedInfo)
+		}
+	}
+	if node.childrenExpiry == safExpired {
+		t.Errorf("children field is still expired")
+	}
+}
+
+func TestResolveSelf(t *testing.T) {
+	node := &safNode{
+		uri:            "0",
+		infoExpiry:     safExpired,
+		childrenExpiry: safExpired,
+		watchManager:   &safWatchManager{},
+	}
+
+	_, opts := newTestClient()
+
+	for _, isDir := range []bool{true, false} {
+		if isDir {
+			node.children = makeChildren(true)
+		} else {
+			node.children = nil
+		}
+
+		for _, path := range []string{"", ".", "/", "a////../././."} {
+			resolved, err := node.Resolve(opts, path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resolved != node {
+				t.Errorf("%q did not return self: %+v != %+v", path, resolved, node)
+			}
+		}
+
+		for _, path := range []string{"..", "/..", "a///////b/../c/../../.."} {
+			resolved, err := node.Resolve(opts, path)
+			if err == nil {
+				t.Errorf("%q did not fail: %+v", path, resolved)
+			}
+		}
+	}
+}
+
+func TestResolveChild(t *testing.T) {
+	node := &safNode{
+		uri:            "0",
+		infoExpiry:     safExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safExpired,
+		watchManager:   &safWatchManager{},
+	}
+
+	client, opts := newTestClient()
+	client.queryChildDocumentsJson = func(documentUri string) (string, error) {
+		depth, _ := strconv.ParseInt(filepath.Base(documentUri), 10, 0)
+		if depth > 2 {
+			return fileInfoListJson(), nil
+		}
+
+		childName := strconv.Itoa(int(depth + 1))
+
+		return fileInfoListJson(&safFileInfo{
+			Uri:    childName,
+			Name_:  childName,
+			IsDir_: depth < 2,
+		}), nil
+	}
+
+	for _, path := range []string{"1", "1/2", "1/2/3"} {
+		child, err := node.Resolve(opts, path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if child.name != filepath.Base(path) {
+			t.Errorf("%q returned incorrect child: %+v", path, child)
+		}
+	}
+
+	child, err := node.Resolve(opts, "1/2/3/4")
+	if !errors.Is(err, syscall.ENOTDIR) {
+		t.Errorf("did not fail with ENOTDIR: %+v: %+v", child, err)
+	}
+
+	child, err = node.Resolve(opts, "1/2/4")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("did not fail with ENOENT: %+v: %+v", child, err)
+	}
+}
+
+func TestDirNames(t *testing.T) {
+	node := &safNode{
+		name:           "0",
+		infoExpiry:     safExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safExpired,
+		watchManager:   &safWatchManager{},
+	}
+
+	client, opts := newTestClient()
+	client.queryChildDocumentsJson = func(documentUri string) (string, error) {
+		count, _ := strconv.ParseInt(filepath.Base(documentUri), 10, 0)
+		children := []*safFileInfo{}
+
+		for i := range count {
+			childName := strconv.Itoa(int(i))
+
+			children = append(children, &safFileInfo{
+				Uri:    childName,
+				Name_:  childName,
+				IsDir_: false,
+			})
+		}
+
+		return fileInfoListJson(children...), nil
+	}
+
+	for count := range 3 {
+		expected := []string{}
+		for i := range count {
+			expected = append(expected, strconv.Itoa(i))
+		}
+
+		node.uri = strconv.Itoa(count)
+		node.childrenExpiry = safExpired
+
+		dirNames, err := node.DirNames(opts, ".")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		slices.Sort(dirNames)
+
+		if !slices.Equal(dirNames, expected) {
+			t.Errorf("invalid child names: %+v != %+v", dirNames, expected)
+		}
+	}
+}
+
+func TestMkdirMissing(t *testing.T) {
+	node := &safNode{
+		uri:            "0",
+		infoExpiry:     safExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safNotExpired,
+		watchManager:   &safWatchManager{},
+	}
+
+	client, opts := newTestClient()
+	client.createDocument = func(parentDocumentUri, mimeType, name string) (string, error) {
+		if mimeType != safMimeTypeDir {
+			t.Errorf("invalid MIME type: %q", mimeType)
+		}
+		return name, nil
+	}
+
+	child, err := node.Mkdir(opts, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if child.name != "1" {
+		t.Errorf("invalid child name: %+v", child)
+	}
+	if _, ok := node.children[child.name]; !ok {
+		t.Errorf("missing child in children: %+v", node)
+	}
+}
+
+func TestMkdirExists(t *testing.T) {
+	watchManager := &safWatchManager{}
+	node := &safNode{
+		uri:            "0",
+		infoExpiry:     safExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safNotExpired,
+		watchManager:   watchManager,
+	}
+	node.children["1"] = &safNode{
+		parent:         node,
+		uri:            "1",
+		name:           "1",
+		infoExpiry:     safNotExpired,
+		childrenExpiry: safExpired,
+		watchManager:   watchManager,
+	}
+
+	client, opts := newTestClient()
+	client.createDocument = func(parentDocumentUri, mimeType, name string) (string, error) {
+		if mimeType != safMimeTypeDir {
+			t.Errorf("invalid MIME type: %q", mimeType)
+		}
+		return name, nil
+	}
+
+	for _, path := range []string{".", "1"} {
+		child, err := node.Mkdir(opts, path)
+		if !errors.Is(err, os.ErrExist) {
+			t.Errorf("%q: did not fail with EEXIST: %+v: %+v", path, child, err)
+		}
+	}
+}
+
+func TestMkdirAll(t *testing.T) {
+	watchManager := &safWatchManager{}
+	node := &safNode{
+		uri:            "0",
+		infoExpiry:     safExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safNotExpired,
+		watchManager:   watchManager,
+	}
+	node.children["1"] = &safNode{
+		parent:         node,
+		uri:            "1",
+		name:           "1",
+		infoExpiry:     safNotExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safNotExpired,
+		watchManager:   watchManager,
+	}
+
+	client, opts := newTestClient()
+	client.createDocument = func(parentDocumentUri, mimeType, name string) (string, error) {
+		if mimeType != safMimeTypeDir {
+			t.Errorf("invalid MIME type: %q", mimeType)
+		}
+		return name, nil
+	}
+
+	child, isNew, err := node.MkdirAll(opts, "1/2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isNew {
+		t.Errorf("did not report child as new: %+v", child)
+	}
+	if child.name != "2" {
+		t.Errorf("invalid child name: %+v", child)
+	}
+
+	oldChild := child
+
+	child, isNew, err = node.MkdirAll(opts, "1/2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if isNew {
+		t.Errorf("child reported as new: %+v", child)
+	}
+	if child != oldChild {
+		t.Errorf("child changed: %p (%+v) != %p (%+v)", child, child, oldChild, oldChild)
+	}
+}
+
+func TestOpenFileMissing(t *testing.T) {
+	node := &safNode{
+		uri:            "0",
+		infoExpiry:     safExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safNotExpired,
+		watchManager:   &safWatchManager{},
+	}
+
+	client, opts := newTestClient()
+	client.createDocument = func(parentDocumentUri, mimeType, name string) (string, error) {
+		if mimeType != safMimeTypeFile {
+			t.Errorf("invalid MIME type: %q", mimeType)
+		}
+		return name, nil
+	}
+	client.openDocument = func(documentUri, mode string) (int, error) {
+		if mode != "rwt" {
+			t.Errorf("invalid mode: %q", mode)
+		}
+		return syscall.Dup(syscall.Stdout)
+	}
+
+	file, err := node.OpenFile(opts, "1", os.O_RDWR|os.O_CREATE|os.O_TRUNC)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file.Close()
+
+	file, err = node.OpenFile(opts, "2", os.O_RDONLY)
+	if !errors.Is(err, os.ErrNotExist) {
+		if file != nil {
+			file.Close()
+		}
+		t.Errorf("did not fail with ENOENT: %+v: %+v", file, err)
+	}
+}
+
+func TestOpenFileExists(t *testing.T) {
+	node := &safNode{
+		uri:            "0",
+		infoExpiry:     safExpired,
+		childrenExpiry: safExpired,
+		watchManager:   &safWatchManager{},
+	}
+
+	client, opts := newTestClient()
+	client.createDocument = func(parentDocumentUri, mimeType, name string) (string, error) {
+		if mimeType != safMimeTypeDir {
+			t.Errorf("invalid MIME type: %q", mimeType)
+		}
+		return name, nil
+	}
+	client.openDocument = func(documentUri, mode string) (int, error) {
+		if mode != "rw" {
+			t.Errorf("invalid mode: %q", mode)
+		}
+		return syscall.Dup(syscall.Stdin)
+	}
+
+	file, err := node.OpenFile(opts, ".", os.O_RDWR|os.O_CREATE)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file.Close()
+
+	file, err = node.OpenFile(opts, ".", os.O_RDWR|os.O_CREATE|os.O_EXCL)
+	if !errors.Is(err, os.ErrExist) {
+		if file != nil {
+			file.Close()
+		}
+		t.Errorf("did not fail with EEXIST: %+v", err)
+	}
+}
+
+func TestRemove(t *testing.T) {
+	watchManager := &safWatchManager{}
+	node := &safNode{
+		uri:            "0",
+		infoExpiry:     safNotExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safNotExpired,
+		watchManager:   watchManager,
+	}
+	node.children["1"] = &safNode{
+		parent:         node,
+		uri:            "1",
+		name:           "1",
+		infoExpiry:     safNotExpired,
+		childrenExpiry: safExpired,
+		watchManager:   watchManager,
+	}
+
+	client, opts := newTestClient()
+	client.deleteDocument = func(documentUri string) error {
+		if documentUri != "1" {
+			t.Errorf("deleting incorrect file: %q", documentUri)
+		}
+		return nil
+	}
+
+	err := node.Remove(opts, ".")
+	if !errors.Is(err, syscall.ENOTEMPTY) {
+		t.Errorf("did not fail with ENOTEMPTY: %+v", err)
+	}
+
+	err = node.Remove(opts, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = node.Remove(opts, "2")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("did not fail with ENOENT: %+v", err)
+	}
+}
+
+func TestRemoveAll(t *testing.T) {
+	watchManager := &safWatchManager{}
+	node := &safNode{
+		uri:            "0",
+		infoExpiry:     safNotExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safNotExpired,
+		watchManager:   watchManager,
+	}
+	node.children["1"] = &safNode{
+		parent:         node,
+		uri:            "1",
+		name:           "1",
+		infoExpiry:     safNotExpired,
+		childrenExpiry: safExpired,
+		watchManager:   watchManager,
+	}
+
+	client, opts := newTestClient()
+	client.deleteDocument = func(documentUri string) error {
+		if documentUri != "1" {
+			t.Errorf("deleting incorrect file: %q", documentUri)
+		}
+		return nil
+	}
+
+	if err := node.RemoveAll(opts, "1"); err != nil {
+		t.Error(err)
+	}
+	if err := node.RemoveAll(opts, "1"); err != nil {
+		t.Error(err)
+	}
+	if err := node.RemoveAll(opts, ""); !errors.Is(err, os.ErrInvalid) {
+		t.Errorf("deleting root did not fail with EINVAL: %+v", err)
+	}
+}
+
+func TestRename(t *testing.T) {
+	watchManager := &safWatchManager{}
+	node := &safNode{
+		uri:            "0",
+		infoExpiry:     safNotExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safNotExpired,
+		watchManager:   watchManager,
+	}
+	node.children["1"] = &safNode{
+		parent:         node,
+		uri:            "1",
+		name:           "1",
+		infoExpiry:     safNotExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safNotExpired,
+		watchManager:   watchManager,
+	}
+	node.children["1"].children["a"] = &safNode{
+		parent:         node.children["1"],
+		uri:            "a",
+		name:           "a",
+		infoExpiry:     safNotExpired,
+		childrenExpiry: safExpired,
+		watchManager:   watchManager,
+	}
+	node.children["2"] = &safNode{
+		parent:         node,
+		uri:            "2",
+		name:           "2",
+		infoExpiry:     safNotExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safExpired,
+		watchManager:   watchManager,
+	}
+
+	client, opts := newTestClient()
+	client.moveDocument = func(sourceDocumentUri, sourceParentDocumentUri, targetParentDocumentUri string) (string, error) {
+		if sourceDocumentUri != "a" {
+			t.Errorf("invalid source: %q", sourceDocumentUri)
+		}
+		if sourceParentDocumentUri != "1" {
+			t.Errorf("invalid source parent: %q", sourceParentDocumentUri)
+		}
+		if targetParentDocumentUri != "2" {
+			t.Errorf("invalid target parent: %q", targetParentDocumentUri)
+		}
+		return sourceDocumentUri, nil
+	}
+	client.renameDocument = func(documentUri, name string) (string, error) {
+		if documentUri != "a" {
+			t.Errorf("invalid document: %q", documentUri)
+		}
+		if name != "b" {
+			t.Errorf("invalid name: %q", name)
+		}
+		return name, nil
+	}
+
+	oldChild := node.children["1"].children["a"]
+
+	child, err := node.Rename(opts, "1/a", "2/b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if child == oldChild {
+		t.Errorf("child did not change despite URI changing")
+	}
+
+	if _, err := node.Rename(opts, "", "3"); !errors.Is(err, os.ErrInvalid) {
+		t.Errorf("renaming root did not fail with EINVAL: %+v", err)
+	}
+	if _, err := node.Rename(opts, "1", ""); !errors.Is(err, os.ErrInvalid) {
+		t.Errorf("replacing root did not fail with EINVAL: %+v", err)
+	}
+}
+
+func TestStat(t *testing.T) {
+	node := &safNode{
+		uri:            "0",
+		name:           "1",
+		size:           2,
+		mtime:          3,
+		infoExpiry:     safNotExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safExpired,
+		watchManager:   &safWatchManager{},
+	}
+
+	_, opts := newTestClient()
+
+	info, err := node.Stat(opts, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Uri != node.uri {
+		t.Errorf("invalid URI: %q != %q", info.Uri, node.uri)
+	} else if info.Name_ != node.name {
+		t.Errorf("invalid name: %q != %q", info.Name_, node.name)
+	} else if info.Size_ != node.size {
+		t.Errorf("invalid size: %v != %v", info.Size_, node.size)
+	} else if info.Mtime != node.mtime {
+		t.Errorf("invalid mtime: %v != %v", info.Mtime, node.mtime)
+	} else if info.IsDir_ != (node.children != nil) {
+		t.Errorf("invalid isDir: %v != %v", info.IsDir_, node.children != nil)
+	}
+}
+
+type mockObserver struct{}
+
+func (mo *mockObserver) Cancel() {}
+
+func TestWatch(t *testing.T) {
+	watchManager := &safWatchManager{}
+	node := &safNode{
+		uri:            "0",
+		infoExpiry:     safNotExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safNotExpired,
+		watchManager:   watchManager,
+	}
+	node.children["1"] = &safNode{
+		parent:         node,
+		uri:            "1",
+		name:           "1",
+		infoExpiry:     safNotExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safNotExpired,
+		watchManager:   watchManager,
+	}
+
+	client, opts := newTestClient()
+	client.observeDocument = func(documentUri string, changeListener SafChangeListener) (SafObserver, error) {
+		go func() { changeListener.OnChange() }()
+		return &mockObserver{}, nil
+	}
+
+	ctx := context.TODO()
+	out := make(chan fs.Event)
+
+	if err := watchManager.Start(opts, node, ctx, &mockMatcher{}, out); err != nil {
+		t.Fatal(err)
+	}
+
+	events := []string{}
+	for range 2 {
+		events = append(events, (<-out).Name)
+	}
+	slices.Sort(events)
+
+	expected := []string{"", "1"}
+
+	if !slices.Equal(events, expected) {
+		t.Errorf("invalid events: %+v != %+v", events, expected)
+	}
+	if node.childrenExpiry != safExpired {
+		t.Errorf("root's children not expired: %v", node.childrenExpiry)
+	}
+	if node.children["1"].childrenExpiry != safExpired {
+		t.Errorf("child's children not expired: %v", node.children["1"].childrenExpiry)
+	}
+
+	if err := watchManager.Stop(node); err != nil {
+		t.Fatal(err)
+	}
+
+	if node.observer != nil {
+		t.Errorf("root's observer still exists: %+v", node.observer)
+	}
+	if node.children["1"].observer != nil {
+		t.Errorf("child's observer still exists: %+v", node.children["1"].observer)
+	}
+}
+
+func TestGlob(t *testing.T) {
+	watchManager := &safWatchManager{}
+	node := &safNode{
+		uri:            "0",
+		infoExpiry:     safNotExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safNotExpired,
+		watchManager:   watchManager,
+	}
+	node.children["1"] = &safNode{
+		parent:         node,
+		uri:            "1",
+		name:           "1",
+		infoExpiry:     safNotExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safNotExpired,
+		watchManager:   watchManager,
+	}
+	node.children["1"].children["a"] = &safNode{
+		parent:         node.children["1"],
+		uri:            "a",
+		name:           "a",
+		infoExpiry:     safNotExpired,
+		childrenExpiry: safExpired,
+		watchManager:   watchManager,
+	}
+	node.children["2"] = &safNode{
+		parent:         node,
+		uri:            "2",
+		name:           "2",
+		infoExpiry:     safNotExpired,
+		children:       makeChildren(true),
+		childrenExpiry: safNotExpired,
+		watchManager:   watchManager,
+	}
+
+	_, opts := newTestClient()
+
+	for _, i := range []struct {
+		glob     string
+		expected []string
+	}{
+		{glob: "", expected: []string{}},
+		{glob: "3", expected: []string{}},
+		{glob: "1", expected: []string{"1"}},
+		{glob: "*", expected: []string{"1", "2"}},
+		{glob: "*/a", expected: []string{"1/a"}},
+		{glob: "*/[abc]", expected: []string{"1/a"}},
+		{glob: "*/*", expected: []string{"1/a"}},
+		{glob: "*/*/*", expected: []string{}},
+	} {
+		results, err := node.Glob(opts, i.glob)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		slices.Sort(results)
+
+		if !slices.Equal(results, i.expected) {
+			t.Errorf("%q: invalid matches: %+v != %+v", i.glob, results, i.expected)
+		}
+	}
+}

--- a/stbridge/stbridge.go
+++ b/stbridge/stbridge.go
@@ -3,9 +3,6 @@
 
 package stbridge
 
-// #include <android/api-level.h>
-import "C"
-
 import (
 	// This package's init() MUST run first.
 	_ "stbridge/pidfdhack"
@@ -21,6 +18,7 @@ import (
 	"log"
 	"log/slog"
 	"net"
+	_ "net/http"
 	"os"
 	"path/filepath"
 	"slices"
@@ -59,13 +57,13 @@ func cleanOldFiles() {
 	// We only clean up a subset of what upstream syncthing does since the
 	// initial release started with 2.x and certain features aren't enabled.
 	locationGlobs := map[string]map[string]time.Duration{
-		locations.GetBaseDir(locations.ConfigBaseDir): map[string]time.Duration{
+		locations.GetBaseDir(locations.ConfigBaseDir): {
 			"panic-*.log":   7 * 24 * time.Hour,
 			"config.xml.v*": 30 * 24 * time.Hour,
 			// From before version 2.3.
 			"support-bundle-*": 30 * 24 * time.Hour,
 		},
-		locations.GetBaseDir(locations.SupportBundleBaseDir): map[string]time.Duration{
+		locations.GetBaseDir(locations.SupportBundleBaseDir): {
 			"support-bundle-*": 30 * 24 * time.Hour,
 		},
 	}
@@ -294,6 +292,8 @@ func (app *SyncthingApp) GuiTlsCert() []byte {
 }
 
 type SyncthingStatusReceiver interface {
+	OnCheckStoragePermissions(internal0Sep string, external0Sep string) error
+
 	OnSyncthingStarted(app *SyncthingApp)
 
 	OnSyncthingStopped(app *SyncthingApp)
@@ -349,7 +349,7 @@ func dispatchConflicts(
 	for folder, names := range conflictsInfo.byFolder {
 		folderPath := conflictsInfo.folderPaths[folder]
 
-		for name, _ := range names {
+		for name := range names {
 			if paths0Sep.Len() > 0 {
 				paths0Sep.WriteRune('\u0000')
 			}
@@ -463,7 +463,7 @@ func dispatchDeviceStates(
 	syncing := int32(0)
 	pending := int32(0)
 
-	for deviceID, _ := range deviceStates.dirty {
+	for deviceID := range deviceStates.dirty {
 		if _, ok := deviceStates.connected[deviceID]; ok {
 			syncing += 1
 		} else {
@@ -715,6 +715,10 @@ func eventLoop(
 				alertsInfo.needsRestart = cfgWrapper.RequiresRestart()
 				dispatchAlerts(alertsInfo, receiver)
 
+				// Let Syncthing service know so that outdated (ignored by user)
+				// permission warnings for external storage can be removed.
+				_ = checkStoragePermissions(cfg, receiver)
+
 			default:
 				log.Printf("Unexpected event: %+v", evt)
 			}
@@ -786,11 +790,39 @@ func startEventLoop(
 	return nil
 }
 
+func checkStoragePermissions(
+	cfg config.Configuration,
+	receiver SyncthingStatusReceiver,
+) error {
+	var internal0Sep strings.Builder
+	var external0Sep strings.Builder
+
+	for _, folder := range cfg.Folders {
+		var builder *strings.Builder
+
+		if folder.FilesystemType == config.FilesystemTypeBasic {
+			builder = &internal0Sep
+		} else if folder.FilesystemType == config.FilesystemType(filesystemTypeSaf) {
+			builder = &external0Sep
+		} else {
+			continue
+		}
+
+		if builder.Len() > 0 {
+			builder.WriteRune('\u0000')
+		}
+		builder.WriteString(folder.Path)
+	}
+
+	return receiver.OnCheckStoragePermissions(internal0Sep.String(), external0Sep.String())
+}
+
 type SyncthingStartupConfig struct {
 	DeviceModel string
 	Proxy       string
 	NoProxy     string
 	Receiver    SyncthingStatusReceiver
+	CheckOnly   bool
 }
 
 func Run(startup *SyncthingStartupConfig) error {
@@ -824,6 +856,19 @@ func Run(startup *SyncthingStartupConfig) error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 	go cfg.Serve(ctx)
+
+	if err := checkStoragePermissions(cfg.RawCopy(), startup.Receiver); err != nil {
+		// We intentionally don't fail with an error because we don't want to
+		// show this as a fatal error to the user. There's special handling for
+		// permissions in SyncthingService.
+		log.Printf("Exiting because storage permissions denied: %v", err)
+		return nil
+	}
+
+	if startup.CheckOnly {
+		log.Print("This was a storage permission check only run")
+		return nil
+	}
 
 	waiter, err := cfg.Modify(func(c *config.Configuration) {
 		// Try to stick with existing ports, but always allow picking new ones


### PR DESCRIPTION
This adds support for using Android's Storage Access Framework via Syncthing's custom filesystem support. The scheme is:

    Filesystem type: saf
    Filesystem path: <URL-encoded SAF tree URI>/<subpath>

The SAF tree URI is URL-encoded because of how Syncthing uses `filepath` functions on the return value of `fs.Filesystem.URI()`. SAF URIs are opaque values that cannot be broken up and URL-encoding them eliminates directory separators (slashes) while still keeping them mostly human readable, unlike eg. base64. These strings are user-facing.

Sadly, SAF is a really, really terrible API for general file access, and we have to introduce a custom caching VFS layer to make it remotely performant and usable. There are many issues:

* Accessing files by path is not possible. SAF URIs are opaque and finding the URI of a child requires listing the parent directory first. Unfortunately, this is an extremely expensive operation, at least for AOSP's `FileSystemProvider`. It triggers an `lstat` on every child with no way to prevent this behavior. We make the best we can out of this by caching child metadata every time we list a directory.

* There is nothing as granular as inotify. The best we have is a "something changed" event reported while the `queryChildDocuments()` `Cursor` is kept open. At least for AOSP's `FileSystemProvider`, the events are internally based on sane inotify events, but since we don't get any event details, we have to trigger a subtree rescan every time the event fires. Additionally, this is not a recursive watcher, so our custom VFS needs to handle that itself.

* Creating a file or directory is not atomic. If a file is created by another app in between BasicSync checking for its existence and creating it, the newly created file will have a different filename with a numeric suffix. There is no guarantee that the file being opened is the same file that was created since creation and opening are two separate operations. `O_EXCL` is also subject to races.

* Non-recursively deleting a directory is prone to races. SAF only supports recursive delete, so `rmdir` semantics has to be implemented at the VFS layer, which is subject to TOCTOU issues.

* Updating mtime is not supported. This operation just doesn't exist in SAF.

* The only documented exception that SAF providers can throw is `FileNotFoundException`. Technically, the implementation allows them to throw a few other `Parcelable` exceptions, but nothing that would help with identifying eg. `ENOENT` vs. `EACCES`. As such, the VFS layer treats all SAF errors as `ENOENT`.

* SAF only guarantees that a seekable file descriptor is returned when opening the `ParcelFileDescriptor` as "rw". We hardcode a special exception for AOSP's builtin `com.android.externalstorage.documents`, since we know "r" and "w" will return seekable file descriptors, but for all other SAF providers, we're stuck with "rw". The VFS layer works around this by blocking read and write calls itself.

In order to avoid significantly complicating the VFS implementation, there are some things that aren't supported:

* The URI and name of each entry is immutable. If the SAF provider's `queryDocument()` implementation returns a different value than what was originally returned when the VFS node was constructed from `queryChildDocuments()`, then the metadata fetch operation will fail. In particular, this means if there was a SAF-level file conflict that resulted in a numeric suffix being appended, querying its metadata or its child entries will fail after the cache expires due to immutable names.

* Moving or renaming a file or directory will always throw away its entire cached subtree. This is to keep each node's parent pointer immutable to avoid needing much more complicated locking. In practice, this doesn't matter much since most people probably will use an SD card and AOSP's `FileSystemProvider` returns new URIs for moved/renamed files, so reusing a cached subtree is impossible anyway.

On the UI front, we now defer requesting local storage permissions until they are needed. If the user only ever uses SAF, it will not be requested. We still need to make sure that Syncthing can never start when it's missing local storage permissions and a local folder is configured though, or else it will sync the "empty" folder and wipe out the user's data. This is not needed for SAF since the marker folder will be inaccessible, leaving the folder in a failed state. Granting permissions always restarts the service so that the user does not need to pause and unpause the folder to get it out of the failed state.

The actual permissions check is a bit awkward now, in that it happens after the Syncthing config is loaded in stbridge, but before the service runs. This so that we can reuse Syncthing's config parsing logic to determine whether there are any local folders and also which SAF URIs are in use. If there are missing permissions, the service startup is interrupted and `SyncthingService` will plumb that info through to bound clients, like `SettingsScreen`, so that the user can grant the permissions. Making this work complicates `SyncthingService` a bit since we now need to start the service once, even if the user configured it to be manually stopped.

Finally, if the user uses SAF, exported configs will no longer be fully compatible with other Syncthing apps. This entire feature relies on Syncthing's builtin custom filesystem support, but no other app will understand BasicSync's custom filesystem scheme.

...but hey! At least BasicSync can sync folders on SD cards now...