### PR TITLE
SyncthingTileService: Disable tile when service is not running

### DIFF
--- a/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
+++ b/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
@@ -53,6 +53,35 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
         val ACTION_RECHECK = "${SyncthingService::class.java.canonicalName}.restart"
         val ACTION_EXIT = "${SyncthingService::class.java.canonicalName}.exit"
 
+        private val isRunningListeners = HashSet<OnServiceRunningChange>()
+        private var isRunning: Boolean = false
+            set(value) {
+                synchronized(isRunningListeners) {
+                    field = value
+                    for (listener in isRunningListeners) {
+                        listener.onServiceRunningChanged(value)
+                    }
+                }
+            }
+
+        fun registerIsRunningListener(listener: OnServiceRunningChange) {
+            synchronized(isRunningListeners) {
+                if (!isRunningListeners.add(listener)) {
+                    Log.w(TAG, "Listener was already registered: $listener")
+                }
+
+                listener.onServiceRunningChanged(isRunning)
+            }
+        }
+
+        fun unregisterIsRunningListener(listener: OnServiceRunningChange) {
+            synchronized(isRunningListeners) {
+                if (!isRunningListeners.remove(listener)) {
+                    Log.w(TAG, "Listener was never registered: $listener")
+                }
+            }
+        }
+
         fun createIntent(context: Context, action: String?) =
             Intent(context, SyncthingService::class.java).apply {
                 this.action = action
@@ -98,6 +127,10 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
                         or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
             )
         }
+    }
+
+    interface OnServiceRunningChange {
+        fun onServiceRunningChanged(isRunning: Boolean)
     }
 
     enum class RunState {
@@ -369,6 +402,7 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
 
     override fun onCreate() {
         super.onCreate()
+        isRunning = true
 
         prefs = Preferences(this)
         prefs.registerListener(this)
@@ -385,6 +419,7 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
 
     override fun onDestroy() {
         super.onDestroy()
+        isRunning = false
 
         // We intentionally don't wait for runnerThread to exit. Syncthing can sometimes take a few
         // seconds to fully exit, which can trigger an ANR warning. This is not a problem because if

--- a/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingTileService.kt
+++ b/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingTileService.kt
@@ -13,12 +13,14 @@ import android.util.Log
 import com.chiller3.basicsync.Preferences
 import com.chiller3.basicsync.R
 
-class SyncthingTileService : TileService(), SharedPreferences.OnSharedPreferenceChangeListener {
+class SyncthingTileService : TileService(), SharedPreferences.OnSharedPreferenceChangeListener,
+    SyncthingService.OnServiceRunningChange {
     companion object {
         private val TAG = SyncthingTileService::class.java.simpleName
     }
 
     private lateinit var prefs: Preferences
+    private var serviceRunning = false
 
     override fun onCreate() {
         super.onCreate()
@@ -29,6 +31,7 @@ class SyncthingTileService : TileService(), SharedPreferences.OnSharedPreference
     override fun onStartListening() {
         super.onStartListening()
         prefs.registerListener(this)
+        SyncthingService.registerIsRunningListener(this)
 
         refreshTileState()
     }
@@ -36,12 +39,16 @@ class SyncthingTileService : TileService(), SharedPreferences.OnSharedPreference
     override fun onStopListening() {
         super.onStopListening()
         prefs.unregisterListener(this)
+        SyncthingService.unregisterIsRunningListener(this)
     }
 
     override fun onClick() {
         super.onClick()
 
-        val action = if (!prefs.isManualMode) {
+        val action = if (!serviceRunning) {
+            // Exited -> previous desired state.
+            SyncthingService.ACTION_RENOTIFY
+        } else if (!prefs.isManualMode) {
             // Auto mode -> manually started.
             SyncthingService.ACTION_START
         } else if (prefs.manualShouldRun) {
@@ -69,7 +76,12 @@ class SyncthingTileService : TileService(), SharedPreferences.OnSharedPreference
             return
         }
 
-        if (!prefs.isManualMode) {
+        if (!serviceRunning) {
+            // Exited.
+            tile.state = Tile.STATE_INACTIVE
+            tile.label = getString(R.string.app_name)
+            tile.icon = Icon.createWithResource(this, R.drawable.ic_notifications)
+        } else if (!prefs.isManualMode) {
             // Auto mode.
             tile.state = Tile.STATE_ACTIVE
             tile.label = getString(R.string.quick_settings_tile_auto_mode)
@@ -87,5 +99,10 @@ class SyncthingTileService : TileService(), SharedPreferences.OnSharedPreference
         }
 
         tile.updateTile()
+    }
+
+    override fun onServiceRunningChanged(isRunning: Boolean) {
+        serviceRunning = isRunning
+        refreshTileState()
     }
 }


### PR DESCRIPTION
Tapping on the tile in this state will start the app in the user's last selected mode.

Fixes: #172