### PR TITLE
Add separate persistent notification channel when stopped

### DIFF
--- a/app/src/main/java/com/chiller3/basicsync/Notifications.kt
+++ b/app/src/main/java/com/chiller3/basicsync/Notifications.kt
@@ -23,28 +23,36 @@ import java.io.File
 
 class Notifications(private val context: Context) {
     companion object {
-        private const val CHANNEL_ID_PERSISTENT = "persistent"
+        private const val CHANNEL_ID_PERSISTENT_STARTED = "persistent"
+        private const val CHANNEL_ID_PERSISTENT_STOPPED = "persistent_stopped"
         private const val CHANNEL_ID_FAILURE = "failure"
         private const val CHANNEL_ID_CONFLICTS = "conflicts"
         private const val CHANNEL_ID_ALERTS = "alerts"
 
         private val LEGACY_CHANNEL_IDS = arrayOf<String>()
 
-        const val ID_PERSISTENT = -1
-        private const val ID_FAILURE = -2
-        private const val ID_CONFLICTS = -3
-        private const val ID_ALERTS = -4
+        const val ID_PERSISTENT_STARTED = -1
+        const val ID_PERSISTENT_STOPPED = -2
+        private const val ID_FAILURE = -3
+        private const val ID_CONFLICTS = -4
+        private const val ID_ALERTS = -5
     }
 
     private val notificationManager = context.getSystemService(NotificationManager::class.java)
 
-    /** Create a low priority notification channel for the persistent notification. */
-    private fun createPersistentChannel() = NotificationChannel(
-        CHANNEL_ID_PERSISTENT,
-        context.getString(R.string.notification_channel_persistent_name),
+    private fun createPersistentStartedChannel() = NotificationChannel(
+        CHANNEL_ID_PERSISTENT_STARTED,
+        context.getString(R.string.notification_channel_persistent_name_started),
         NotificationManager.IMPORTANCE_LOW,
     ).apply {
-        description = context.getString(R.string.notification_channel_persistent_desc)
+        setShowBadge(false)
+    }
+
+    private fun createPersistentStoppedChannel() = NotificationChannel(
+        CHANNEL_ID_PERSISTENT_STOPPED,
+        context.getString(R.string.notification_channel_persistent_name_stopped),
+        NotificationManager.IMPORTANCE_LOW,
+    ).apply {
         setShowBadge(false)
     }
 
@@ -79,7 +87,8 @@ class Notifications(private val context: Context) {
      */
     fun updateChannels() {
         notificationManager.createNotificationChannels(listOf(
-            createPersistentChannel(),
+            createPersistentStartedChannel(),
+            createPersistentStoppedChannel(),
             createFailureAlertsChannel(),
             createConflictsAlertsChannel(),
             createSyncthingAlertsChannel(),
@@ -87,7 +96,7 @@ class Notifications(private val context: Context) {
         LEGACY_CHANNEL_IDS.forEach { notificationManager.deleteNotificationChannel(it) }
     }
 
-    fun createPersistentNotification(state: SyncthingService.ServiceState): Notification {
+    fun createPersistentNotification(state: SyncthingService.ServiceState): Pair<Int, Notification> {
         val runState = state.runState
         val titleResId = when (runState) {
             SyncthingService.RunState.RUNNING -> R.string.notification_persistent_running_title
@@ -100,7 +109,13 @@ class Notifications(private val context: Context) {
             SyncthingService.RunState.EXPORTING -> R.string.notification_persistent_exporting_title
         }
 
-        return Notification.Builder(context, CHANNEL_ID_PERSISTENT).run {
+        val (id, channel) = if (runState.showAsRunning) {
+            ID_PERSISTENT_STARTED to CHANNEL_ID_PERSISTENT_STARTED
+        } else {
+            ID_PERSISTENT_STOPPED to CHANNEL_ID_PERSISTENT_STOPPED
+        }
+
+        val notification = Notification.Builder(context, channel).run {
             setContentTitle(context.getString(titleResId))
             setSmallIcon(R.drawable.ic_notifications)
             setOngoing(true)
@@ -203,6 +218,18 @@ class Notifications(private val context: Context) {
 
             build()
         }
+
+        return id to notification
+    }
+
+    fun cancelOppositePersistentNotification(id: Int) {
+        val cancelId = when (id) {
+            ID_PERSISTENT_STARTED -> ID_PERSISTENT_STOPPED
+            ID_PERSISTENT_STOPPED -> ID_PERSISTENT_STARTED
+            else -> throw IllegalArgumentException("Cancelling invalid notification: $id")
+        }
+
+        notificationManager.cancel(cancelId)
     }
 
     fun sendFailureNotification(exception: Exception) {

--- a/app/src/main/java/com/chiller3/basicsync/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/SettingsScreen.kt
@@ -739,8 +739,7 @@ private fun SettingsContent(
 
         item(key = "service_status") {
             SwitchPreference(
-                checked = runState == SyncthingService.RunState.RUNNING
-                        || runState == SyncthingService.RunState.STARTING,
+                checked = runState?.showAsRunning == true,
                 onCheckedChange = onServiceStatusChange,
                 enabled = isManualMode,
                 shapes = BetterSegmentedShapes.top(),

--- a/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
+++ b/app/src/main/java/com/chiller3/basicsync/syncthing/SyncthingService.kt
@@ -143,6 +143,9 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
         IMPORTING,
         EXPORTING;
 
+        val showAsRunning: Boolean
+            get() = this == RUNNING || this == STARTING
+
         val showFolderStates: Boolean
             get() = this == RUNNING
 
@@ -593,7 +596,7 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
                     allListeners { it.onRunStateChanged(notificationState, guiInfo) }
                 }
 
-                val notification = notifications.createPersistentNotification(notificationState)
+                val (id, notification) = notifications.createPersistentNotification(notificationState)
                 val useLocation = deviceStateTracker.canUseLocation()
                 var type = 0
 
@@ -604,7 +607,8 @@ class SyncthingService : Service(), SyncthingStatusReceiver, DeviceStateListener
                     type = type or ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
                 }
 
-                ServiceCompat.startForeground(this, Notifications.ID_PERSISTENT, notification, type)
+                ServiceCompat.startForeground(this, id, notification, type)
+                notifications.cancelOppositePersistentNotification(id)
 
                 if (lastUseLocation != useLocation) {
                     deviceStateTracker.refreshNetworkState()

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -118,8 +118,6 @@
     <string name="dialog_wifi_network_hint">SSID</string>
     <string name="web_ui_select_folder">اختر مجلد</string>
     <string name="web_ui_scan_qr_code">امسح رمز QR</string>
-    <string name="notification_channel_persistent_name">خدمات الخلفية</string>
-    <string name="notification_channel_persistent_desc">يسمح لـSyncthing بالعمل في الخلفية</string>
     <string name="notification_channel_failure_name">إنذارات الأعطال</string>
     <string name="notification_channel_failure_desc">إنذارات لأخطاء بدء تشغيل Syncthing</string>
     <string name="notification_channel_conflicts_name">تعارضات المزامنة</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -93,8 +93,6 @@
     <string name="dialog_wifi_network_hint">SSID</string>
     <string name="web_ui_select_folder">Изберете папка</string>
     <string name="web_ui_scan_qr_code">Сканиране на QR код</string>
-    <string name="notification_channel_persistent_name">Фонови услуги</string>
-    <string name="notification_channel_persistent_desc">Поддържа Syncthing работещ във фонов режим</string>
     <string name="notification_channel_failure_name">Сигнали за грешки</string>
     <string name="notification_channel_failure_desc">Сигнали за грешки при стартиране на Syncthing</string>
     <string name="notification_channel_conflicts_name">Конфликти при синхронизация</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -83,8 +83,6 @@
     <string name="dialog_wifi_network_hint">SSID</string>
     <string name="web_ui_select_folder">Ordner auswählen</string>
     <string name="web_ui_scan_qr_code">QR-Code scannen</string>
-    <string name="notification_channel_persistent_name">Hintergrunddienste</string>
-    <string name="notification_channel_persistent_desc">Hält Syncthing im Hintergrund laufen</string>
     <string name="notification_channel_failure_name">Fehlermeldungen</string>
     <string name="notification_channel_failure_desc">Warnhinweise für Fehlern beim Starten von Syncthing</string>
     <string name="notification_persistent_running_title">Syncthing wird ausgeführt</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -86,8 +86,6 @@
     <string name="dialog_wifi_network_hint">SSID</string>
     <string name="web_ui_select_folder">Seleccione carpeta</string>
     <string name="web_ui_scan_qr_code">Escanee código QR</string>
-    <string name="notification_channel_persistent_name">Servicios en segundo plano</string>
-    <string name="notification_channel_persistent_desc">Mantiene Syncthing ejecutando en segundo plano</string>
     <string name="notification_channel_failure_name">Alertas de fracaso</string>
     <string name="notification_channel_failure_desc">Alerta para errores al iniciar Syncthing</string>
     <string name="notification_persistent_running_title">Syncthing se está ejecutando</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -90,8 +90,6 @@
     <string name="dialog_wifi_network_message">Sisesta WiFi võrgu nimi (SSID). See toimib ka peidetud WiFi võrkude puhul.</string>
     <string name="web_ui_select_folder">Vali kaust</string>
     <string name="web_ui_scan_qr_code">Skanneeri QR-koodi</string>
-    <string name="notification_channel_persistent_name">Taustateenused</string>
-    <string name="notification_channel_persistent_desc">Hoiab Syncthingi taustal töös</string>
     <string name="notification_action_auto_mode">Automaatne režiim</string>
     <string name="notification_action_manual_mode">Käsitsi režiim</string>
     <string name="notification_action_exit">Välju</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -95,8 +95,6 @@
     <string name="web_ui_select_folder">Sélectionner un répertoire</string>
     <string name="web_ui_scan_qr_code">Scanner le code QR</string>
     <!-- Notifications -->
-    <string name="notification_channel_persistent_name">Services en arrière-plan</string>
-    <string name="notification_channel_persistent_desc">Maintient Syncthing en cours d\'exécution en arrière-plan</string>
     <string name="notification_channel_failure_name">Alertes d\'échec</string>
     <string name="notification_channel_failure_desc">Alertes pour les erreurs lors du démarrage de Syncthing</string>
     <string name="notification_persistent_running_title">Syncthing est en cours d\'exécution</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -95,8 +95,6 @@
     <string name="web_ui_select_folder">Mappa kiválasztása</string>
     <string name="web_ui_scan_qr_code">QR-kód beolvasása</string>
     <!-- Notifications -->
-    <string name="notification_channel_persistent_name">Háttérszolgáltatások</string>
-    <string name="notification_channel_persistent_desc">A Syncthing futtatása a háttérben</string>
     <string name="notification_channel_failure_name">Hiba értesítések</string>
     <string name="notification_channel_failure_desc">Értesítések a Syncthing indítási hibáiról</string>
     <string name="notification_persistent_running_title">A Syncthing fut</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -87,8 +87,6 @@
     <string name="dialog_wifi_network_hint">SSID</string>
     <string name="web_ui_select_folder">Pilih folder</string>
     <string name="web_ui_scan_qr_code">Pindai kode QR</string>
-    <string name="notification_channel_persistent_name">Layanan latar belakang</string>
-    <string name="notification_channel_persistent_desc">Menjaga Syncthing tetap berjalan di latar belakang</string>
     <string name="notification_channel_failure_name">Peringatan kegagalan</string>
     <string name="notification_channel_failure_desc">Peringatan untuk kesalahan saat memulai Syncthing</string>
     <string name="notification_persistent_running_title">Syncthing sedang berjalan</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -87,8 +87,6 @@
     <string name="dialog_wifi_network_hint">SSID</string>
     <string name="web_ui_select_folder">בחירת תיקייה</string>
     <string name="web_ui_scan_qr_code">סריקת קוד QR</string>
-    <string name="notification_channel_persistent_name">שירותי רקע</string>
-    <string name="notification_channel_persistent_desc">שומר על ריצת Syncthing ברקע</string>
     <string name="notification_channel_failure_name">התרעות כשל</string>
     <string name="notification_channel_failure_desc">התרעות עבור שגיאות בעת התחלת Syncthing</string>
     <string name="notification_persistent_running_title">היישום Syncthing פועל</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -84,8 +84,6 @@
     <string name="dialog_wifi_network_hint">SSID</string>
     <string name="web_ui_select_folder">Wybierz folder</string>
     <string name="web_ui_scan_qr_code">Skanuj kod QR</string>
-    <string name="notification_channel_persistent_name">Usługi w tle</string>
-    <string name="notification_channel_persistent_desc">Utrzymuje działanie Syncthing w tle</string>
     <string name="notification_channel_failure_name">Alerty o awariach</string>
     <string name="notification_channel_failure_desc">Alerty dotyczące błędów podczas uruchamiania Syncthing</string>
     <string name="notification_persistent_running_title">Syncthing działa</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -95,8 +95,6 @@
     <string name="web_ui_select_folder">Selectează dosarul</string>
     <string name="web_ui_scan_qr_code">Scanează codul QR</string>
     <!-- Notifications -->
-    <string name="notification_channel_persistent_name">Servicii de fundal</string>
-    <string name="notification_channel_persistent_desc">Păstrează Syncthing să ruleze în fundal</string>
     <string name="notification_channel_failure_name">Alerte de defecțiuni</string>
     <string name="notification_channel_failure_desc">Alerte pentru erori la pornirea Syncthing</string>
     <string name="notification_persistent_running_title">Syncthing rulează</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -87,8 +87,6 @@
     <string name="dialog_wifi_network_hint">SSID</string>
     <string name="web_ui_select_folder">Klasör seç</string>
     <string name="web_ui_scan_qr_code">QR kodunu tara</string>
-    <string name="notification_channel_persistent_name">Arka plan hizmetleri</string>
-    <string name="notification_channel_persistent_desc">Syncthing\'i arka planda çalışır tutar</string>
     <string name="notification_channel_failure_name">Arıza uyarıları</string>
     <string name="notification_channel_failure_desc">Eşitleme başlatılırken hataların uyarıları</string>
     <string name="notification_persistent_running_title">Syncthing çalışıyor</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -88,8 +88,6 @@
     <string name="dialog_wifi_network_hint">SSID</string>
     <string name="web_ui_select_folder">选择文件夹</string>
     <string name="web_ui_scan_qr_code">扫描二维码</string>
-    <string name="notification_channel_persistent_name">后台服务</string>
-    <string name="notification_channel_persistent_desc">保持 Syncthing 在后台运行</string>
     <string name="notification_channel_failure_name">失败提醒</string>
     <string name="notification_channel_failure_desc">启动 Syncthing 时出错的提醒</string>
     <string name="notification_persistent_running_title">Syncthing 正在运行</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -95,8 +95,6 @@
     <string name="web_ui_select_folder">選取資料夾</string>
     <string name="web_ui_scan_qr_code">掃描 QR Code</string>
     <!-- Notifications -->
-    <string name="notification_channel_persistent_name">背景服務</string>
-    <string name="notification_channel_persistent_desc">保持 Syncthing 於背景執行</string>
     <string name="notification_channel_failure_name">失敗警示</string>
     <string name="notification_channel_failure_desc">啟動 Syncthing 發生錯誤時的警示</string>
     <string name="notification_persistent_running_title">Syncthing 正在執行</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -246,10 +246,10 @@
     <!-- Tooltip shown in Syncthing's web UI for scanning a QR code when adding a new device. Keep as short as possible. -->
     <string name="web_ui_scan_qr_code">Scan QR code</string>
 
-    <!-- Name of the Android notification channel for the persistent notification that is always shown. -->
-    <string name="notification_channel_persistent_name">Background services</string>
-    <!-- Description of the Android notification channel for the persistent notification that is always shown. -->
-    <string name="notification_channel_persistent_desc">Keeps Syncthing running in the background</string>
+    <!-- Name of the Android notification channel for the persistent notification when Syncthing is running. -->
+    <string name="notification_channel_persistent_name_started">Persistent notification when started</string>
+    <!-- Name of the Android notification channel for the persistent notification when Syncthing is stopped. -->
+    <string name="notification_channel_persistent_name_stopped">Persistent notification when stopped</string>
     <!-- Name of the Android notification channel for notifications about errors. -->
     <string name="notification_channel_failure_name">Failure alerts</string>
     <!-- Description of the Android notification channel for notifications about errors. -->


### PR DESCRIPTION
Also, remove the description for the persistent notification channel because it's inaccurate. Only the broader notification permission is needed to keep the foreground service alive. The specific notification channel can be disabled with no impact.

Fixes: #175