### PR TITLE
ui: Adjust background color to match AOSP SettingsLib

### DIFF
--- a/app/src/main/java/com/chiller3/basicsync/ui/Preferences.kt
+++ b/app/src/main/java/com/chiller3/basicsync/ui/Preferences.kt
@@ -78,9 +78,9 @@ object PreferenceDefaults {
     val ListPadding = PaddingValues(horizontal = HorizontalPadding)
 
     val containerColor: Color
-        @Composable get() = MaterialTheme.colorScheme.surfaceContainerHigh
+        @Composable get() = MaterialTheme.colorScheme.surfaceContainer
     val scrolledContainerColor: Color
-        @Composable get() = MaterialTheme.colorScheme.surfaceContainerLow
+        @Composable get() = MaterialTheme.colorScheme.surfaceContainerHighest
 
     @Composable
     fun appBarColors() = TopAppBarDefaults.topAppBarColors(

--- a/app/src/main/java/com/chiller3/basicsync/ui/Screen.kt
+++ b/app/src/main/java/com/chiller3/basicsync/ui/Screen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.SnackbarHost
@@ -57,7 +56,7 @@ fun AppScreen(
                             IconButton(
                                 onClick = onClick,
                                 colors = IconButtonDefaults.filledIconButtonColors(
-                                    containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                                    containerColor = PreferenceDefaults.scrolledContainerColor,
                                 ),
                             ) {
                                 @SuppressLint("PrivateResource")

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -11,6 +11,6 @@
             the same app.
             This must be set statically. Keep this in sync with PreferenceDefaults.containerColor.
         -->
-        <item name="android:colorBackground">?attr/colorSurfaceContainerHigh</item>
+        <item name="android:colorBackground">?attr/colorSurfaceContainer</item>
     </style>
 </resources>


### PR DESCRIPTION
The previous color was set to Compose's default background color for dialogs, which looked nice, but didn't match AOSP Settings. However, it resulted in relatively low contrast with the filled back button icon background due to the colors being only one step apart instead of two.