### PR TITLE
Screen: Fix opaque back icon when app bar is translucent

### DIFF
--- a/app/src/main/java/com/chiller3/basicsync/ui/Screen.kt
+++ b/app/src/main/java/com/chiller3/basicsync/ui/Screen.kt
@@ -56,7 +56,13 @@ fun AppScreen(
                             IconButton(
                                 onClick = onClick,
                                 colors = IconButtonDefaults.filledIconButtonColors(
-                                    containerColor = PreferenceDefaults.scrolledContainerColor,
+                                    containerColor = PreferenceDefaults.scrolledContainerColor.let {
+                                        if (fullScreenContent) {
+                                            it.copy(alpha = 0.5f)
+                                        } else {
+                                            it
+                                        }
+                                    },
                                 ),
                             ) {
                                 @SuppressLint("PrivateResource")


### PR DESCRIPTION
This was visible in the QR code scanner activity