### PR TITLE
Clean up English strings

### DIFF
--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -1,31 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="pref_header_permissions">Permissions</string>
-    <string name="pref_header_configuration">Configuration</string>
-    <string name="pref_header_run_conditions">Run conditions</string>
-    <string name="pref_header_advanced">Advanced</string>
-    <string name="pref_header_about">About</string>
-    <string name="pref_header_debug">Debug</string>
     <string name="pref_inhibit_battery_opt_name">Disable battery optimisation</string>
-    <string name="pref_inhibit_battery_opt_desc">Needed to run reliably in the background.</string>
-    <string name="pref_allow_notifications_name">Allow notifications</string>
-    <string name="pref_allow_notifications_desc">Needed to run reliably in the background and to start and stop Syncthing.</string>
-    <string name="pref_local_storage_access_name">Allow local storage access</string>
-    <string name="pref_local_storage_access_desc">Needed for Syncthing to access the local storage under <tt>/sdcard</tt>.</string>
-    <string name="pref_disable_app_hibernation_name">Disable app hibernation</string>
-    <string name="pref_disable_app_hibernation_desc">Needed to prevent Android from automatically removing app permissions after a period of time.</string>
-    <string name="pref_open_web_ui_name">Open web UI</string>
-    <string name="pref_open_web_ui_desc">Open Syncthing\'s web configuration interface.</string>
-    <string name="pref_import_configuration_name">Import configuration</string>
-    <string name="pref_import_configuration_desc">Import an existing Syncthing configuration zip file.</string>
-    <string name="pref_export_configuration_name">Export configuration</string>
-    <string name="pref_export_configuration_desc">Export the current Syncthing configuration to a zip file.</string>
-    <string name="pref_service_status_name">Syncthing status</string>
-    <string name="pref_auto_mode_name">Auto mode</string>
-    <string name="pref_auto_mode_desc">Automatically start and stop based on the specified conditions.</string>
-    <string name="pref_network_conditions_name">Network conditions</string>
-    <string name="pref_network_conditions_desc">Run when connected to certain network types or Wi-Fi networks.</string>
-    <string name="pref_run_on_battery_name">Run on battery power</string>
-    <string name="pref_run_on_battery_desc">Run when the device is on battery power and the battery level is at least %1$d%%. Syncthing always runs when plugged in.</string>
-    <string name="pref_conflicts_name">Sync conflicts</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,7 +57,7 @@
     <!-- Title for the preference to export the Syncthing configuration. -->
     <string name="pref_export_configuration_name">Export configuration</string>
     <!-- Description for the preference to export the current Syncthing configuration to a zip file. -->
-    <string name="pref_export_configuration_desc">Export current Syncthing configuration to a zip file.</string>
+    <string name="pref_export_configuration_desc">Export the current Syncthing configuration to a zip file.</string>
     <!-- Title for the preference that shows the current status of Syncthing. The notification_persistent_* strings are used for the description. -->
     <string name="pref_service_status_name">Syncthing status</string>
     <!-- Title for the preference that controls whether to use auto mode. Auto mode is where Syncthing is automatically started and stopped based on the run conditions. -->


### PR DESCRIPTION
* Remove en-GB strings that are identical to the originals.
* Add missing "the" in `pref_export_configuration_desc`.