### PR TITLE
DeviceState: Fix updateIdleState() idempotency when already idle

### DIFF
--- a/app/src/main/java/com/chiller3/basicsync/syncthing/DeviceState.kt
+++ b/app/src/main/java/com/chiller3/basicsync/syncthing/DeviceState.kt
@@ -519,6 +519,7 @@ class DeviceStateTracker(private val context: Context) :
             idleStart = System.currentTimeMillis()
         } else {
             Log.d(TAG, "Already idle")
+            idleStart = state.idleStart
         }
 
         state = state.copy(idleStart = idleStart)


### PR DESCRIPTION
Previously, the "already idle" state was potentially reset when updating the busy folder count, the connected device count, or when the user changed any sync schedule setting.

This was a regression introduced in commit 2d70b8299551849a5ac73aee2248c3ba8899603a.

Fixes: #212