### PR TITLE
external/go: Update to go1.27.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/chenxiaolong/syncthing.git
 [submodule "external/go"]
 	path = external/go
-	url = https://github.com/chenxiaolong/go.git
+	url = https://github.com/golang/go.git

--- a/README.md
+++ b/README.md
@@ -208,9 +208,6 @@ Before building, the following tools must be installed:
 * Android SDK
 * Android NDK
 * `go` (golang compiler)
-  * We use a fork of golang that includes a fix for MTE-related crashes. However, an existing golang compiler must still be installed in order to build the fork from source.
-    * https://github.com/golang/go/issues/27610
-    * https://github.com/golang/go/issues/59090
 
 Once the dependencies are installed, BasicSync can be built like most other Android apps using Android Studio or the gradle command line.
 


### PR DESCRIPTION
A fork is no longer needed as 1.27.0 includes both MTE fixes. For reproducible builds, we'll still continue to build the toolchain from source.