### PR TITLE
Add separate network condition for cellular data roaming

### DIFF
--- a/app/src/main/java/com/chiller3/basicsync/Preferences.kt
+++ b/app/src/main/java/com/chiller3/basicsync/Preferences.kt
@@ -28,6 +28,7 @@ class Preferences(context: Context) {
         const val PREF_REQUIRE_UNMETERED_NETWORK = "require_unmetered_network"
         const val PREF_NETWORK_ALLOW_WIFI = "network_allow_wifi"
         const val PREF_NETWORK_ALLOW_CELLULAR = "network_allow_cellular"
+        const val PREF_NETWORK_ALLOW_ROAMING = "network_allow_roaming"
         const val PREF_NETWORK_ALLOW_ETHERNET = "network_allow_ethernet"
         const val PREF_NETWORK_ALLOW_OTHER = "network_allow_other"
         const val PREF_ALLOWED_WIFI_NETWORKS = "allowed_wifi_networks"
@@ -106,6 +107,10 @@ class Preferences(context: Context) {
     var networkAllowCellular: Boolean
         get() = prefs.getBoolean(PREF_NETWORK_ALLOW_CELLULAR, true)
         set(enabled) = prefs.edit { putBoolean(PREF_NETWORK_ALLOW_CELLULAR, enabled) }
+
+    var networkAllowRoaming: Boolean
+        get() = prefs.getBoolean(PREF_NETWORK_ALLOW_ROAMING, false)
+        set(enabled) = prefs.edit { putBoolean(PREF_NETWORK_ALLOW_ROAMING, enabled) }
 
     var networkAllowEthernet: Boolean
         get() = prefs.getBoolean(PREF_NETWORK_ALLOW_ETHERNET, true)

--- a/app/src/main/java/com/chiller3/basicsync/settings/NetworkConditionsScreen.kt
+++ b/app/src/main/java/com/chiller3/basicsync/settings/NetworkConditionsScreen.kt
@@ -52,6 +52,7 @@ fun NetworkConditionsScreen(
     val requireUnmeteredNetwork = remember(reloadPrefs) { prefs.requireUnmeteredNetwork }
     val networkAllowWifi = remember(reloadPrefs) { prefs.networkAllowWifi }
     val networkAllowCellular = remember(reloadPrefs) { prefs.networkAllowCellular }
+    val networkAllowRoaming = remember(reloadPrefs) { prefs.networkAllowRoaming }
     val networkAllowEthernet = remember(reloadPrefs) { prefs.networkAllowEthernet }
     val networkAllowOther = remember(reloadPrefs) { prefs.networkAllowOther }
 
@@ -97,6 +98,7 @@ fun NetworkConditionsScreen(
             requireUnmeteredNetwork = requireUnmeteredNetwork,
             networkAllowWifi = networkAllowWifi,
             networkAllowCellular = networkAllowCellular,
+            networkAllowRoaming = networkAllowRoaming,
             networkAllowEthernet = networkAllowEthernet,
             networkAllowOther = networkAllowOther,
             preciseLocationGranted = preciseLocationGranted,
@@ -113,6 +115,10 @@ fun NetworkConditionsScreen(
             },
             onNetworkAllowCellularChange = { enabled ->
                 prefs.networkAllowCellular = enabled
+                reloadPrefs++
+            },
+            onNetworkAllowRoamingChange = { enabled ->
+                prefs.networkAllowRoaming = enabled
                 reloadPrefs++
             },
             onNetworkAllowEthernetChange = { enabled ->
@@ -149,6 +155,7 @@ fun NetworkConditionsContent(
     requireUnmeteredNetwork: Boolean,
     networkAllowWifi: Boolean,
     networkAllowCellular: Boolean,
+    networkAllowRoaming: Boolean,
     networkAllowEthernet: Boolean,
     networkAllowOther: Boolean,
     preciseLocationGranted: Boolean,
@@ -158,6 +165,7 @@ fun NetworkConditionsContent(
     onRequireUnmeteredNetworkChange: (Boolean) -> Unit,
     onNetworkAllowWifiChange: (Boolean) -> Unit,
     onNetworkAllowCellularChange: (Boolean) -> Unit,
+    onNetworkAllowRoamingChange: (Boolean) -> Unit,
     onNetworkAllowEthernetChange: (Boolean) -> Unit,
     onNetworkAllowOtherChange: (Boolean) -> Unit,
     onPreciseLocationGrant: () -> Unit,
@@ -203,6 +211,16 @@ fun NetworkConditionsContent(
                 onCheckedChange = onNetworkAllowCellularChange,
                 shapes = BetterSegmentedShapes.middle(),
                 title = { Text(text = stringResource(R.string.pref_network_allow_cellular_name)) },
+                modifier = Modifier.animateItem(),
+            )
+        }
+
+        item(key = "network_allow_roaming") {
+            SwitchPreference(
+                checked = networkAllowRoaming,
+                onCheckedChange = onNetworkAllowRoamingChange,
+                shapes = BetterSegmentedShapes.middle(),
+                title = { Text(text = stringResource(R.string.pref_network_allow_roaming_name)) },
                 modifier = Modifier.animateItem(),
             )
         }
@@ -383,6 +401,7 @@ private fun PreviewNetworkConditionsScreen() {
                 requireUnmeteredNetwork = true,
                 networkAllowWifi = true,
                 networkAllowCellular = true,
+                networkAllowRoaming = false,
                 networkAllowEthernet = true,
                 networkAllowOther = true,
                 preciseLocationGranted = false,
@@ -392,6 +411,7 @@ private fun PreviewNetworkConditionsScreen() {
                 onRequireUnmeteredNetworkChange = {},
                 onNetworkAllowWifiChange = {},
                 onNetworkAllowCellularChange = {},
+                onNetworkAllowRoamingChange = {},
                 onNetworkAllowEthernetChange = {},
                 onNetworkAllowOtherChange = {},
                 onPreciseLocationGrant = {},

--- a/app/src/main/java/com/chiller3/basicsync/syncthing/DeviceState.kt
+++ b/app/src/main/java/com/chiller3/basicsync/syncthing/DeviceState.kt
@@ -39,6 +39,7 @@ import kotlin.math.roundToInt
 enum class NetworkType {
     WIFI,
     CELLULAR,
+    ROAMING,
     ETHERNET,
     OTHER,
 }
@@ -147,6 +148,7 @@ data class DeviceState(
             val networkAllowed = when (networkType) {
                 NetworkType.WIFI -> prefs.networkAllowWifi
                 NetworkType.CELLULAR -> prefs.networkAllowCellular
+                NetworkType.ROAMING -> prefs.networkAllowRoaming
                 NetworkType.ETHERNET -> prefs.networkAllowEthernet
                 NetworkType.OTHER -> prefs.networkAllowOther
             }
@@ -305,7 +307,11 @@ class DeviceStateTracker(private val context: Context) :
         val networkType = if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
             NetworkType.WIFI
         } else if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
-            NetworkType.CELLULAR
+            if (capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_ROAMING)) {
+                NetworkType.CELLULAR
+            } else {
+                NetworkType.ROAMING
+            }
         } else if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
             NetworkType.ETHERNET
         } else {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,12 +126,14 @@
     <string name="pref_header_allowed_wifi_networks">Allowed Wi-Fi networks</string>
     <!-- Section header for all available Wi-Fi networks that the user can pick from. -->
     <string name="pref_header_available_wifi_networks">Available Wi-Fi networks</string>
-    <!-- Preference for whether to allow syncing on unmetered networks. This is for unmetered networks of all types (Wi-Fi, unlimited cellular data, ethernet, etc.). -->
+    <!-- Preference for whether to allow syncing on unmetered networks. This is for unmetered networks of all types (Wi-Fi, ethernet, etc.). -->
     <string name="pref_require_unmetered_network_name">Require unmetered network</string>
     <!-- Preference for whether to allow syncing on Wi-Fi. -->
     <string name="pref_network_allow_wifi_name">Allow Wi-Fi</string>
-    <!-- Preference for whether to allow syncing on cellular data. -->
+    <!-- Preference for whether to allow syncing on cellular data (when not roaming). -->
     <string name="pref_network_allow_cellular_name">Allow mobile data</string>
+    <!-- Preference for whether to allow syncing on cellular data (when roaming). -->
+    <string name="pref_network_allow_roaming_name">Allow mobile data (roaming)</string>
     <!-- Preference for whether to allow syncing on ethernet. -->
     <string name="pref_network_allow_ethernet_name">Allow ethernet</string>
     <!-- Preference for whether to allow syncing on all other types of interfaces. This is for uncommon network interfaces, like bluetooth tethering or satellite internet. -->


### PR DESCRIPTION
Android has no toggle to mark a cellular network as unmetered, so turning off the require unmetered network option to allow syncing on unlimited cellular plans would previously also cause syncing to occur when roaming.

Fixes: #233